### PR TITLE
feat/add-configs-factory-module-import-and-usage

### DIFF
--- a/src/gens-templates/__snapshots__/http-listen-action.template.spec.ts.snap
+++ b/src/gens-templates/__snapshots__/http-listen-action.template.spec.ts.snap
@@ -3,11 +3,12 @@
 exports[`httpListenActionTemplate generates bootstrap script 1`] = `
 "// @ts-nocheck
 import { HTTPLister } from './../mode_modules/actioman/lib/esm/http-router/http-listener.js';
-import { factory } from './../undefined';
+import { factory } from './../mode_modules/actioman/lib/esm/configs/configs-factory.js';
+import { Configs } from './../mode_modules/actioman/lib/esm/configs/configs.js';
 const PORT = process.env.PORT;
 const HOST = process.env.HOST;
 const bootstrap = async () => {
-    const configs = Configs.fromModule(await factory.findOn(new URL('./../undefined/', import.meta.url).toString(), 'configs'));
+    const configs = Configs.fromModule(await factory.findOn(new URL('./../', import.meta.url).toString(), 'configs'));
     const httpLister = await HTTPLister.fromModule(await import('./../actios-1/actions.js'), configs);
     const url = await httpLister.listen(PORT, HOST);
     console.log(\`Server running at \${ url.toString() }\`);

--- a/src/gens-templates/__snapshots__/http-listen-action.template.spec.ts.snap
+++ b/src/gens-templates/__snapshots__/http-listen-action.template.spec.ts.snap
@@ -3,10 +3,12 @@
 exports[`httpListenActionTemplate generates bootstrap script 1`] = `
 "// @ts-nocheck
 import { HTTPLister } from './../mode_modules/actioman/lib/esm/http-router/http-listener.js';
+import { factory } from './../undefined';
 const PORT = process.env.PORT;
 const HOST = process.env.HOST;
 const bootstrap = async () => {
-    const httpLister = await HTTPLister.fromModule(await import('./../actios-1/actions.js'));
+    const configs = Configs.fromModule(await factory.findOn(new URL('./../undefined/', import.meta.url).toString(), 'configs'));
+    const httpLister = await HTTPLister.fromModule(await import('./../actios-1/actions.js'), configs);
     const url = await httpLister.listen(PORT, HOST);
     console.log(\`Server running at \${ url.toString() }\`);
 };

--- a/src/gens-templates/http-listen-action.template.spec.ts
+++ b/src/gens-templates/http-listen-action.template.spec.ts
@@ -6,10 +6,17 @@ describe("httpListenActionTemplate", () => {
     expect(
       httpListenActionTemplate({
         target: "file://app/scripts/serve.js",
+        workspaceLocation: "file://app/",
         actionFileLocation: "file://mys-actions/actios-1/actions.js",
         modules: {
           httpListenerModuleLocation: new URL(
             "file://app/mode_modules/actioman/lib/esm/http-router/http-listener.js",
+          ).toString(),
+          configsFactoryModuleLocation: new URL(
+            "file://app/mode_modules/actioman/lib/esm/configs/configs-factory.js",
+          ).toString(),
+          configsModuleLocation: new URL(
+            "file://app/mode_modules/actioman/lib/esm/configs/configs.js",
           ).toString(),
         },
       }),

--- a/src/gens-templates/http-listen-action.template.ts
+++ b/src/gens-templates/http-listen-action.template.ts
@@ -3,7 +3,9 @@ import * as path from "path";
 
 type ProgramASTProps = {
   httpListenerModuleLocation: string;
+  configsFactoryModuleLocation: string;
   actionFileLocation: string;
+  workspaceLocation: string;
 };
 
 const getProgramAST = (props: ProgramASTProps) => ({
@@ -27,6 +29,26 @@ const getProgramAST = (props: ProgramASTProps) => ({
       source: {
         type: "Literal",
         value: props.httpListenerModuleLocation,
+      },
+    },
+    {
+      type: "ImportDeclaration",
+      specifiers: [
+        {
+          type: "ImportSpecifier",
+          local: {
+            type: "Identifier",
+            name: "factory",
+          },
+          imported: {
+            type: "Identifier",
+            name: "factory",
+          },
+        },
+      ],
+      source: {
+        type: "Literal",
+        value: props.configsFactoryModuleLocation,
       },
     },
 
@@ -120,6 +142,106 @@ const getProgramAST = (props: ProgramASTProps) => ({
                       type: "VariableDeclarator",
                       id: {
                         type: "Identifier",
+                        name: "configs",
+                      },
+                      init: {
+                        type: "CallExpression",
+                        callee: {
+                          type: "MemberExpression",
+                          computed: false,
+                          object: {
+                            type: "Identifier",
+                            name: "Configs",
+                          },
+                          property: {
+                            type: "Identifier",
+                            name: "fromModule",
+                          },
+                        },
+                        arguments: [
+                          {
+                            type: "AwaitExpression",
+                            argument: {
+                              type: "CallExpression",
+                              callee: {
+                                type: "MemberExpression",
+                                computed: false,
+                                object: {
+                                  type: "Identifier",
+                                  name: "factory",
+                                },
+                                property: {
+                                  type: "Identifier",
+                                  name: "findOn",
+                                },
+                              },
+                              arguments: [
+                                {
+                                  type: "CallExpression",
+                                  callee: {
+                                    type: "MemberExpression",
+                                    computed: false,
+                                    object: {
+                                      type: "NewExpression",
+                                      callee: {
+                                        type: "Identifier",
+                                        name: "URL",
+                                      },
+                                      arguments: [
+                                        {
+                                          type: "Literal",
+                                          value: props.workspaceLocation,
+                                        },
+                                        {
+                                          type: "MemberExpression",
+                                          computed: false,
+                                          object: {
+                                            type: "MemberExpression",
+                                            computed: false,
+                                            object: {
+                                              type: "Identifier",
+                                              name: "import",
+                                            },
+                                            property: {
+                                              type: "Identifier",
+                                              name: "meta",
+                                            },
+                                          },
+                                          property: {
+                                            type: "Identifier",
+                                            name: "url",
+                                          },
+                                        },
+                                      ],
+                                    },
+                                    property: {
+                                      type: "Identifier",
+                                      name: "toString",
+                                    },
+                                  },
+                                  arguments: [],
+                                },
+                                {
+                                  type: "Literal",
+                                  value: "configs",
+                                  raw: '"configs"',
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  kind: "const",
+                },
+                {
+                  type: "VariableDeclaration",
+                  declarations: [
+                    {
+                      type: "VariableDeclarator",
+                      id: {
+                        type: "Identifier",
                         name: "httpLister",
                       },
                       init: {
@@ -154,6 +276,10 @@ const getProgramAST = (props: ProgramASTProps) => ({
                                   },
                                 ],
                               },
+                            },
+                            {
+                              type: "Identifier",
+                              name: "configs",
                             },
                           ],
                         },
@@ -307,8 +433,10 @@ const getProgramAST = (props: ProgramASTProps) => ({
 type Props = {
   target: string;
   actionFileLocation: string;
+  workspaceLocation: string;
   modules: {
     httpListenerModuleLocation: string;
+    configsFactoryModuleLocation: string;
   };
 };
 
@@ -317,8 +445,12 @@ export const httpListenActionTemplate = (props: Props) => {
   const filename = resolvePath(props.target);
   const dirname = new URL("./", filename);
   const actionFileLocation = resolvePath(props.actionFileLocation);
+  const workspaceLocation = resolvePath(props.workspaceLocation);
   const httpListenerModuleLocation = resolvePath(
     props.modules.httpListenerModuleLocation,
+  );
+  const configsFactoryModuleLocation = resolvePath(
+    props.modules.configsFactoryModuleLocation,
   );
 
   const relative = (path2: URL) => {
@@ -327,7 +459,9 @@ export const httpListenActionTemplate = (props: Props) => {
 
   const ast = getProgramAST({
     httpListenerModuleLocation: relative(httpListenerModuleLocation),
+    configsFactoryModuleLocation: relative(configsFactoryModuleLocation),
     actionFileLocation: relative(actionFileLocation),
+    workspaceLocation: `${relative(workspaceLocation)}/`,
   });
 
   return `// @ts-nocheck\n${escodegen.generate(ast)}`;

--- a/src/gens-templates/http-listen-action.template.ts
+++ b/src/gens-templates/http-listen-action.template.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 type ProgramASTProps = {
   httpListenerModuleLocation: string;
+  configsModuleLocation: string;
   configsFactoryModuleLocation: string;
   actionFileLocation: string;
   workspaceLocation: string;
@@ -49,6 +50,26 @@ const getProgramAST = (props: ProgramASTProps) => ({
       source: {
         type: "Literal",
         value: props.configsFactoryModuleLocation,
+      },
+    },
+    {
+      type: "ImportDeclaration",
+      specifiers: [
+        {
+          type: "ImportSpecifier",
+          local: {
+            type: "Identifier",
+            name: "Configs",
+          },
+          imported: {
+            type: "Identifier",
+            name: "Configs",
+          },
+        },
+      ],
+      source: {
+        type: "Literal",
+        value: props.configsModuleLocation,
       },
     },
 
@@ -436,6 +457,7 @@ type Props = {
   workspaceLocation: string;
   modules: {
     httpListenerModuleLocation: string;
+    configsModuleLocation: string;
     configsFactoryModuleLocation: string;
   };
 };
@@ -449,6 +471,9 @@ export const httpListenActionTemplate = (props: Props) => {
   const httpListenerModuleLocation = resolvePath(
     props.modules.httpListenerModuleLocation,
   );
+  const configsModuleLocation = resolvePath(
+    props.modules.configsModuleLocation,
+  );
   const configsFactoryModuleLocation = resolvePath(
     props.modules.configsFactoryModuleLocation,
   );
@@ -459,6 +484,7 @@ export const httpListenActionTemplate = (props: Props) => {
 
   const ast = getProgramAST({
     httpListenerModuleLocation: relative(httpListenerModuleLocation),
+    configsModuleLocation: relative(configsModuleLocation),
     configsFactoryModuleLocation: relative(configsFactoryModuleLocation),
     actionFileLocation: relative(actionFileLocation),
     workspaceLocation: `${relative(workspaceLocation)}/`,

--- a/src/scripts/__snapshots__/make-server-script.spec.ts.snap
+++ b/src/scripts/__snapshots__/make-server-script.spec.ts.snap
@@ -3,10 +3,12 @@
 exports[`makeServerScript generates bootstrap script 1`] = `
 "// @ts-nocheck
 import { HTTPLister } from './../lib/esm/http-router/http-listener.js';
+import { factory } from './../lib/esm/configs/modules/factory.js';
 const PORT = process.env.PORT;
 const HOST = process.env.HOST;
 const bootstrap = async () => {
-    const httpLister = await HTTPLister.fromModule(await import('./../../../actions.js'));
+    const configs = Configs.fromModule(await factory.findOn(new URL('./../../../', import.meta.url).toString(), 'configs'));
+    const httpLister = await HTTPLister.fromModule(await import('./../../../actions.js'), configs);
     const url = await httpLister.listen(PORT, HOST);
     console.log(\`Server running at \${ url.toString() }\`);
 };

--- a/src/scripts/__snapshots__/make-server-script.spec.ts.snap
+++ b/src/scripts/__snapshots__/make-server-script.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`makeServerScript generates bootstrap script 1`] = `
 "// @ts-nocheck
 import { HTTPLister } from './../lib/esm/http-router/http-listener.js';
 import { factory } from './../lib/esm/configs/modules/factory.js';
+import { Configs } from './../lib/esm/configs/configs.js';
 const PORT = process.env.PORT;
 const HOST = process.env.HOST;
 const bootstrap = async () => {

--- a/src/scripts/findConfigsFactoryFileModule.ts
+++ b/src/scripts/findConfigsFactoryFileModule.ts
@@ -1,0 +1,12 @@
+import { findActiomanNodeModulesPaths } from "./findNodeModulesPaths.js";
+
+export async function findConfigsFactoryFileModule(cwd: URL) {
+  const actiomanNodeModulePath: URL | null =
+    (await findActiomanNodeModulesPaths(cwd).next()).value ?? null;
+  if (!actiomanNodeModulePath) throw new Error("actioman is not installed");
+  const actionsFolder = new URL(
+    "./lib/esm/configs/modules/factory.js",
+    actiomanNodeModulePath,
+  );
+  return actionsFolder;
+}

--- a/src/scripts/findConfigsFileModule.ts
+++ b/src/scripts/findConfigsFileModule.ts
@@ -1,0 +1,12 @@
+import { findActiomanNodeModulesPaths } from "./findNodeModulesPaths.js";
+
+export async function findConfigsFileModule(cwd: URL) {
+  const actiomanNodeModulePath: URL | null =
+    (await findActiomanNodeModulesPaths(cwd).next()).value ?? null;
+  if (!actiomanNodeModulePath) throw new Error("actioman is not installed");
+  const actionsFolder = new URL(
+    "./lib/esm/configs/configs.js",
+    actiomanNodeModulePath,
+  );
+  return actionsFolder;
+}

--- a/src/scripts/make-server-script.ts
+++ b/src/scripts/make-server-script.ts
@@ -2,9 +2,13 @@ import * as fs from "fs/promises";
 import { httpListenActionTemplate } from "../gens-templates/http-listen-action.template.js";
 import { findHTTPListenerFileModule } from "./findHTTPListenerFileModule.js";
 import { makebootstrapHTTPListenerFileModule } from "./makebootstrapHTTPListenerFileModule.js";
+import { findConfigsFactoryFileModule } from "./findConfigsFactoryFileModule.js";
 
 export const makeServerScript = async (cwd: string, actionsPath: string) => {
   const httpListenerLocation = await findHTTPListenerFileModule(
+    new URL(cwd, "file://"),
+  );
+  const configsFactoryLocation = await findConfigsFactoryFileModule(
     new URL(cwd, "file://"),
   );
   const bootstrapLocation = await makebootstrapHTTPListenerFileModule(
@@ -18,8 +22,10 @@ export const makeServerScript = async (cwd: string, actionsPath: string) => {
     httpListenActionTemplate({
       target: bootstrapLocation.pathname,
       actionFileLocation: actionsPath,
+      workspaceLocation: cwd,
       modules: {
         httpListenerModuleLocation: httpListenerLocation.pathname,
+        configsFactoryModuleLocation: configsFactoryLocation.pathname,
       },
     }),
   );

--- a/src/scripts/make-server-script.ts
+++ b/src/scripts/make-server-script.ts
@@ -3,6 +3,7 @@ import { httpListenActionTemplate } from "../gens-templates/http-listen-action.t
 import { findHTTPListenerFileModule } from "./findHTTPListenerFileModule.js";
 import { makebootstrapHTTPListenerFileModule } from "./makebootstrapHTTPListenerFileModule.js";
 import { findConfigsFactoryFileModule } from "./findConfigsFactoryFileModule.js";
+import { findConfigsFileModule } from "./findConfigsFileModule.js";
 
 export const makeServerScript = async (cwd: string, actionsPath: string) => {
   const httpListenerLocation = await findHTTPListenerFileModule(
@@ -11,6 +12,7 @@ export const makeServerScript = async (cwd: string, actionsPath: string) => {
   const configsFactoryLocation = await findConfigsFactoryFileModule(
     new URL(cwd, "file://"),
   );
+  const configsLocation = await findConfigsFileModule(new URL(cwd, "file://"));
   const bootstrapLocation = await makebootstrapHTTPListenerFileModule(
     new URL(cwd, "file://"),
   );
@@ -25,6 +27,7 @@ export const makeServerScript = async (cwd: string, actionsPath: string) => {
       workspaceLocation: cwd,
       modules: {
         httpListenerModuleLocation: httpListenerLocation.pathname,
+        configsModuleLocation: configsLocation.pathname,
         configsFactoryModuleLocation: configsFactoryLocation.pathname,
       },
     }),


### PR DESCRIPTION
## Changes

This pull request introduces the following changes:

1. Added a new function `findConfigsFactoryFileModule` that locates the path to the configs factory file module within the actioman node module. This is necessary for the application to be able to load the factory configuration file dynamically.

2. Added the `configsFactoryModuleLocation` and `workspaceLocation` properties to the `ProgramASTProps` type, and used them to fetch the configs from the configs factory module. This allows the generated code to access the application's configuration settings, which is necessary for the HTTP listener to function correctly.

3. Added the ability to find and include the configs factory module in the generated server script. This allows the server script to access the application's configuration settings, which is necessary for properly bootstrapping the HTTP listener and handling incoming requests.