### PR TITLE
tests(http-listener): add cleanup tasks to tests

### DIFF
--- a/src/gens-templates/__snapshots__/action-document.template.spec.ts.snap
+++ b/src/gens-templates/__snapshots__/action-document.template.spec.ts.snap
@@ -1,0 +1,20 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actionDocumentTemplate should generate the actions target code 1`] = `
+"// @ts-nocheck
+import { z } from 'zod';
+import { ActionsTarget } from './../node_modules/actioman/lib/esm/actions-target/actions-target.js';
+const createActionsTarget = () => new ActionsTarget('http://localhost/', {
+    hi: {
+        description: 'foo',
+        input: z.object({ "name": z.string() }).strict(),
+        output: z.object({ "outname": z.union([z.number(), z.null()]) }).strict()
+    },
+    foo: {
+        description: 'foo',
+        input: undefined,
+        output: z.object({ "outname": z.union([z.number(), z.null()]) }).strict()
+    }
+}).compile();
+export default createActionsTarget;"
+`;

--- a/src/http-router/http-listener.spec.ts
+++ b/src/http-router/http-listener.spec.ts
@@ -1,15 +1,11 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { HTTPLister } from "./http-listener";
 import { HTTPRouter } from "./http-router";
-
-const cleanupTasks = new Set<() => any>();
+import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 
 describe("HTTPLister", () => {
-  afterEach(async () => {
-    for (const cleanupTask of cleanupTasks) await cleanupTask();
-  });
-
   it("should return 404 for unknown paths", async () => {
+    await using cleanupTasks = new CleanupTasks();
     const httpLister = HTTPLister.fromModule({});
     cleanupTasks.add(() => httpLister.close());
     const url = await httpLister.listen();
@@ -20,6 +16,7 @@ describe("HTTPLister", () => {
   });
 
   it("should return 200 for /__actions", async () => {
+    await using cleanupTasks = new CleanupTasks();
     const httpLister = HTTPLister.fromModule({});
     cleanupTasks.add(() => httpLister.close());
     const url = await httpLister.listen();
@@ -30,6 +27,7 @@ describe("HTTPLister", () => {
   });
 
   it("should start a server", async () => {
+    await using cleanupTasks = new CleanupTasks();
     const { default: express } = await import("express");
     const app = express();
     const port = 30_161;
@@ -48,6 +46,7 @@ describe("HTTPLister", () => {
   });
 
   describe("integration tests", () => {
+    const cleanupTasks = new CleanupTasks();
     beforeAll(async () => {
       const { default: express } = await import("express");
       const app = express();
@@ -66,6 +65,10 @@ describe("HTTPLister", () => {
       );
     });
 
+    afterAll(async () => {
+      await cleanupTasks.cleanup();
+    });
+
     it("should return 200 for /__actions", async () => {
       const res = await fetch("http://localhost:30161/__actions");
       expect(res.status).toEqual(200);
@@ -82,6 +85,7 @@ describe("HTTPLister", () => {
   });
 
   it("should create a server with actions", async () => {
+    await using cleanupTasks = new CleanupTasks();
     const httpLister = HTTPLister.fromModule({
       biz: () => true,
       foo: () => true,

--- a/src/scripts/import-remote-actions.spec.ts
+++ b/src/scripts/import-remote-actions.spec.ts
@@ -1,26 +1,13 @@
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { $ } from "../shell/shell";
 import { importRemoteActions } from "./import-remote-actions";
 import { HTTPLister } from "../http-router/http-listener";
 import { defineAction } from "../actions/actions";
-import { set, z } from "zod";
+import { z } from "zod";
 import * as fs from "fs/promises";
+import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 
 describe("import-remote-actions", () => {
-  const cleanupTasks = new Set<() => any>();
-
-  afterEach(async () => {
-    for (const cleanupTask of cleanupTasks) await cleanupTask();
-    cleanupTasks.clear();
-  });
-
   beforeAll(async () => {
     await $`
       rm -rf __tests__/tmp/
@@ -34,6 +21,7 @@ describe("import-remote-actions", () => {
   });
 
   it("imports remote actions", async () => {
+    await using cleanupTasks = new CleanupTasks();
     const httpLister = HTTPLister.fromModule({
       hi: defineAction({
         input: z.object({ name: z.string() }),


### PR DESCRIPTION
## Changes

This pull request adds cleanup tasks to the tests in the `http-listener.spec.ts` file. The changes ensure that the server is properly closed after each test, preventing potential issues with port conflicts or resource leaks.

The main changes are:

- Adding `await using cleanupTasks = new CleanupTasks()` to each test that creates an `HTTPLister` instance. This ensures that the cleanup tasks are properly registered and executed after the test is completed.
- Removing the `afterEach` hook that was previously used to manually clean up the tasks, as the `using` statement now handles this automatically.

These changes improve the reliability and maintainability of the test suite by ensuring that the server is properly cleaned up after each test, making the tests more robust and less prone to flakiness.