### PR TITLE
build: add coverage artifact upload to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,8 @@ jobs:
       - run: bun install
       - run: bun lint
       - run: bun test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/lcov.info
       - run: bunx lcov-summary coverage/lcov.info >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Changes

This pull request adds a coverage artifact upload step to the CI workflow. The new step uploads the coverage report as an artifact, allowing the report to be accessed and viewed after the workflow run completes.