### PR TITLE
tests(share-actions-document): generate share actions document

### DIFF
--- a/src/gens-templates/__snapshots__/share-actions-document.template.spec.ts.snap
+++ b/src/gens-templates/__snapshots__/share-actions-document.template.spec.ts.snap
@@ -8,3 +8,12 @@ export {
     default as taz
 } from './../actions/taz.js';"
 `;
+
+exports[`shareActionsTemplate generates share actions document 1`] = `
+"export {
+    default as foo
+} from './../actions/foo.js';
+export {
+    default as taz
+} from './../actions/taz.js';"
+`;

--- a/src/gens-templates/share-actions-document.template.spec.ts
+++ b/src/gens-templates/share-actions-document.template.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { shareActionsTemplate } from "./share-actions-document.template";
 
 describe("shareActionsTemplate", () => {
-  it("", () => {
+  it("generates share actions document", () => {
     expect(
       shareActionsTemplate({
         fileLocation: "/app/script.js",


### PR DESCRIPTION
## Changes

This pull request generates a share actions document for the `share-actions-document` feature. The changes include:

- Updated the test case in `share-actions-document.template.spec.ts` to describe the purpose of the test, which is to generate a share actions document.
- Updated the snapshot file `share-actions-document.template.spec.ts.snap` to include the expected output of the `shareActionsTemplate` function.

These changes were made to improve the readability and clarity of the test suite, ensuring that the purpose of the test is clearly communicated.