### PR TITLE
build: add issue auto-assign GitHub workflow

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,25 @@
+name: Issue auto assign
+
+on:
+  issues: 
+    types: 
+      - opened
+  pull_request: 
+    types: 
+      - opened
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions: 
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Auto Assign Issue
+        uses: pozil/auto-assign-issue@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: jondotsoy
+          numOfAssignee: 1
+      
+


### PR DESCRIPTION
## Changes

This pull request adds a new GitHub workflow that automatically assigns issues and pull requests to a specific user (jondotsoy) when they are opened. This helps ensure that new issues and PRs are promptly addressed by the assigned maintainer.