### PR TITLE
build: add continue-on-error to issue auto assign workflow

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Auto Assign Issue
         uses: pozil/auto-assign-issue@v1
+        continue-on-error: true
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: jondotsoy


### PR DESCRIPTION
## Changes

This pull request adds the `continue-on-error: true` option to the issue auto assign workflow step. This ensures the workflow continues to execute even if the auto assign step fails, preventing the entire workflow from failing.