### PR TITLE
feat: add actions.md file with action definition examples

### DIFF
--- a/docs/es/actions.md
+++ b/docs/es/actions.md
@@ -1,0 +1,63 @@
+## 📜 Archivo de Acciones: Definiendo tus Servicios Actioman
+
+El archivo de acciones es el corazón de tu servicio Actioman. Por convención, a menudo se nombra `actions.js`, pero **puedes elegir el nombre de archivo que prefieras**. Este archivo Javascript contiene todas las **acciones** o **servicios** que quieres exponer a través de tu API. Actioman escanea este archivo y automáticamente convierte cada función exportada en un endpoint web accesible.
+
+### ¿Qué son las Acciones?
+
+En el contexto de Actioman, una **acción** es simplemente una función Javascript que exportas desde tu archivo de acciones (por ejemplo, `actions.js`). Cada acción representa una funcionalidad específica que deseas poner a disposición de tus clientes (aplicaciones web, móviles, otros servicios, etc.).
+
+### Definiendo Acciones Básicas
+
+La forma más sencilla de definir una acción es exportando una función Javascript estándar.
+
+**Ejemplo: Archivo de acciones (ejemplo: `actions.js`) con acciones básicas**
+
+```js
+// actions.js (o el nombre de archivo que elijas)
+export const hello = () => "hello world";
+export const now = () => Date.now();
+```
+
+En este ejemplo, hemos definido dos acciones:
+
+- `hello`: Una función que retorna la cadena de texto "hello world".
+- `now`: Una función que retorna el timestamp actual usando `Date.now()`.
+
+Cuando ejecutas `npx actioman <nombre-de-tu-archivo-de-acciones>.js` (por ejemplo, `npx actioman actions.js` o `npx actioman mis_servicios.js`), Actioman detecta estas funciones exportadas y crea endpoints para ellas. En este caso, se crearían endpoints POST para `/actions/hello` y `/actions/now`.
+
+### Definiendo Acciones con Contratos (Recomendado)
+
+Para asegurar la type-safety y una mejor experiencia de desarrollo, Actioman te permite definir **contratos** para tus acciones utilizando la librería [Zod](https://zod.dev/). Los contratos especifican la forma y el tipo de datos esperados como entrada (input) y salida (output) de cada acción.
+
+Actioman proporciona la función `defineAction` para facilitar la creación de acciones con contratos.
+
+**Ejemplo: Archivo de acciones (ejemplo: `actions.js`) con acciones y contratos Zod**
+
+```js
+// actions.js (o como hayas nombrado tu archivo)
+import { defineAction } from "actioman";
+import { z } from "zod";
+
+export const hello = defineAction({
+  input: z.object({ name: z.string() }), // Contrato para el input: espera un objeto con una propiedad 'name' de tipo string
+  output: z.string(), // Contrato para el output: retorna una cadena de texto
+  handler: ({ name }) => `hello ${name}!`, // Función handler que implementa la lógica de la acción
+});
+```
+
+**Desglose del ejemplo con `defineAction`:**
+
+- **`import { defineAction } from "actioman";`**: Importamos la función `defineAction` desde la librería `actioman`.
+- **`import {z} from "zod";`**: Importamos la librería Zod para definir esquemas de validación.
+- **`defineAction({ ... })`**: Utilizamos `defineAction` para definir la acción `hello`.
+  - **`input: z.object({ name: z.string() })`**: Define el contrato para los datos de entrada. En este caso, espera un objeto Javascript con una propiedad llamada `name` que debe ser de tipo `string` según Zod.
+  - **`output: z.string()`**: Define el contrato para el valor de retorno de la acción. Aquí, se espera que la función retorne un valor de tipo `string`.
+  - **`handler: ({name}) => \`hello ${name}!\``**: Esta es la función **handler** que contiene la lógica de tu acción. Recibe como argumento un objeto que coincide con la estructura definida en el contrato `input`. En este caso, recibe un objeto con la propiedad `name`. La función handler debe retornar un valor que coincida con el contrato `output`.
+
+### Beneficios de Usar Contratos Zod
+
+Definir contratos con Zod en tu archivo de acciones ofrece varias ventajas importantes, especialmente para los clientes que consumen tu servicio Actioman:
+
+- **Type-Safety para Clientes:** Al usar el comando `actioman add` para agregar tu servicio a un proyecto cliente, Actioman utiliza los contratos Zod definidos para generar automáticamente definiciones de tipos (TypeScript o JSDoc) para tus acciones. Esto permite a los desarrolladores clientes tener **autocompletado**, **validación de tipos en tiempo de desarrollo** y **detección temprana de errores** al usar tus servicios.
+- **Validación de Datos en el Servidor:** Actioman utiliza los contratos Zod en el servidor para **validar los datos de entrada** que recibe en las peticiones a tus acciones. Si los datos no cumplen con el contrato definido, Actioman rechazará la petición con un error, garantizando la integridad de tu servicio.
+- **Documentación Implícita:** Los contratos Zod sirven como una forma de **documentación implícita** para tus acciones. Un cliente puede inspeccionar los contratos para entender qué datos necesita enviar a una acción y qué tipo de dato recibirá como respuesta, sin necesidad de consultar documentación externa.

--- a/docs/es/cli-reference.md
+++ b/docs/es/cli-reference.md
@@ -1,0 +1,83 @@
+# Comandos CLI
+
+Este documento describe los comandos de la interfaz de línea de comandos (CLI) de `actioman`.
+
+## `actioman serve`
+
+El comando `actioman serve` se utiliza para levantar un servidor `actioman` que expone las funciones definidas en un archivo Javascript como servicios web. Por defecto, el servidor se inicia utilizando el protocolo HTTP.
+
+**Uso:**
+
+```bash
+actioman serve <ruta_archivo_de_inicio> [flags]
+```
+
+`<ruta_archivo_de_inicio>`: Especifica la ruta al archivo Javascript que contiene las funciones que se expondrán como servicios. Este archivo suele ser `actions.js`.
+
+**Flags:**
+
+El comando `actioman serve` admite los siguientes flags opcionales para personalizar el comportamiento del servidor:
+
+- `--http2`
+
+  Habilita el protocolo HTTP/2 para el servidor. HTTP/2 ofrece mejoras de rendimiento en comparación con HTTP/1.1, como la multiplexación de peticiones y la compresión de encabezados, lo que puede optimizar la comunicación con el servicio.
+
+  ```bash
+  actioman serve actions.js --http2
+  ```
+
+  Por defecto, al usar `--http2`, el servicio se levanta en modo no seguro (sin SSL). Para configurar la seguridad (HTTPS/2) y utilizar certificados SSL, debes modificar el archivo de configuración `actioman.config.js`. Consulta la documentación detallada sobre la configuración de seguridad en [./actioman.config.js.md](./actioman.config.js.md).
+
+- `--cwd <ruta_directorio>`
+
+  Define el directorio de trabajo actual (current working directory) para el servicio. Esto es útil cuando ejecutas el comando `actioman serve` desde una ubicación que no es la raíz del proyecto donde se encuentra el archivo `<ruta_archivo_de_inicio>`.
+
+  ```bash
+  actioman serve actions.js --cwd /ruta/a/mi/proyecto
+  ```
+
+- `--port <numero_puerto>`
+
+  Especifica el puerto en el que el servidor `actioman` escuchará las peticiones. Por defecto, `actioman` intenta utilizar el puerto `30320`. Si el puerto `30320` ya está en uso, `actioman` buscará automáticamente el siguiente puerto disponible incrementando el valor en uno hasta encontrar un puerto libre.
+
+  ```bash
+  actioman serve actions.js --port 8080
+  ```
+
+- `--host <hostname>`
+
+  Define el hostname o la dirección IP en la que el servidor estará disponible. El valor por defecto es `localhost`, lo que significa que el servicio solo será accesible desde la misma máquina donde se está ejecutando.
+
+  Para permitir el tráfico desde cualquier dirección de red (útil para acceder al servicio desde otras máquinas en la misma red o externamente), puedes usar `::` (para IPv6 y IPv4) o `0.0.0.0` (solo para IPv4).
+
+  **Importante:** El uso de `::` o `0.0.0.0` para abrir el servicio a todas las redes solo se aplica al protocolo HTTP. Para HTTP/2, la configuración del hostname puede requerir ajustes adicionales, especialmente en entornos de producción y con configuraciones de seguridad SSL/TLS.
+
+  ```bash
+  # Permite el acceso desde cualquier dirección IPv4 (solo HTTP)
+  actioman serve actions.js --host 0.0.0.0
+
+  # Permite el acceso desde cualquier dirección IPv6 o IPv4 (solo HTTP)
+  actioman serve actions.js --host ::
+  ```
+
+- `--help`
+
+  Muestra un mensaje de ayuda en la consola que lista todos los comandos disponibles de `actioman` y los flags asociados a cada comando, incluyendo el comando `serve` y sus flags.
+
+  ```bash
+  actioman serve --help
+  ```
+
+**Ejemplo básico:**
+
+Para levantar un servidor `actioman` utilizando el archivo `actions.js` en el puerto por defecto (o el primer puerto libre a partir de `30320`) y utilizando HTTP, simplemente ejecuta:
+
+```bash
+actioman serve actions.js
+```
+
+Este comando iniciará el servidor y mostrará en la consola las rutas generadas para acceder a tus servicios.
+
+**Requerimiento:**
+
+El comando `actioman serve` requiere que se especifique la `<ruta_archivo_de_inicio>` para indicar a `actioman` qué archivo Javascript debe analizar para exponer las funciones como servicios.


### PR DESCRIPTION
## Changes

This pull request adds a new documentation file `actions.md` in the Spanish (`es`) directory. The file provides examples and explanations for defining actions in Actioman, including:

- Basic action definition
- Action definition with Zod contracts
- Benefits of using Zod contracts, such as type-safety for clients, input validation, and implicit documentation

The key changes in this PR are:

- Introducing the concept of "actions" in Actioman and how to define them
- Demonstrating the use of the `defineAction` function and Zod contracts to ensure type-safety and better development experience
- Highlighting the advantages of using Zod contracts, including client-side type-safety, server-side input validation, and implicit documentation