### PR TITLE
feat(http-listen-action): improve template generation

### DIFF
--- a/src/gens-templates/__snapshots__/http-listen-action.template.spec.ts.snap
+++ b/src/gens-templates/__snapshots__/http-listen-action.template.spec.ts.snap
@@ -2,16 +2,17 @@
 
 exports[`httpListenActionTemplate generates bootstrap script 1`] = `
 "// @ts-nocheck
-import { HTTPLister } from './../mode_modules/actioman/lib/esm/http-router/http-listener.js';
-import { factory } from './../mode_modules/actioman/lib/esm/configs/configs-factory.js';
-import { Configs } from './../mode_modules/actioman/lib/esm/configs/configs.js';
+import { HTTPLister } from "./../mode_modules/actioman/lib/esm/http-router/http-listener.js";
+import { factory } from "./../mode_modules/actioman/lib/esm/configs/configs-factory.js";
+import { Configs } from "./../mode_modules/actioman/lib/esm/configs/configs.js";
 const PORT = process.env.PORT;
 const HOST = process.env.HOST;
 const bootstrap = async () => {
-    const configs = Configs.fromModule(await factory.findOn(new URL('./../', import.meta.url).toString(), 'configs'));
-    const httpLister = await HTTPLister.fromModule(await import('./../actios-1/actions.js'), configs);
+    const configs = Configs.fromModule(await factory.findOn(new URL("./../", import.meta.url).toString(), "configs"));
+    const httpLister = await HTTPLister.fromModule(await import("./../actios-1/actions.js"), configs);
     const url = await httpLister.listen(PORT, HOST);
-    console.log(\`Server running at \${ url.toString() }\`);
+    console.log(\`Server running at \${url.toString()}\`);
 };
-bootstrap().catch(console.error);"
+bootstrap().catch(console.error);
+"
 `;

--- a/src/gens-templates/http-listen-action.template.ts
+++ b/src/gens-templates/http-listen-action.template.ts
@@ -1,455 +1,85 @@
-import escodegen from "escodegen";
 import * as path from "path";
+import {
+  $,
+  $template,
+  $import,
+  $const,
+  $call,
+  $await,
+  $string,
+  $new,
+  $statement,
+  $doc,
+  render,
+  $asyncArrowFunction,
+} from "./typescript-factory/typescript-factory.js";
 
 type ProgramASTProps = {
   httpListenerModuleLocation: string;
   configsModuleLocation: string;
   configsFactoryModuleLocation: string;
-  actionFileLocation: string;
-  workspaceLocation: string;
+  actionRelativeFileLocation: string;
+  relativeWorkspaceLocation: string;
 };
 
-const getProgramAST = (props: ProgramASTProps) => ({
-  type: "Program",
-  body: [
-    {
-      type: "ImportDeclaration",
-      specifiers: [
-        {
-          type: "ImportSpecifier",
-          local: {
-            type: "Identifier",
-            name: "HTTPLister",
-          },
-          imported: {
-            type: "Identifier",
-            name: "HTTPLister",
-          },
-        },
-      ],
-      source: {
-        type: "Literal",
-        value: props.httpListenerModuleLocation,
-      },
-    },
-    {
-      type: "ImportDeclaration",
-      specifiers: [
-        {
-          type: "ImportSpecifier",
-          local: {
-            type: "Identifier",
-            name: "factory",
-          },
-          imported: {
-            type: "Identifier",
-            name: "factory",
-          },
-        },
-      ],
-      source: {
-        type: "Literal",
-        value: props.configsFactoryModuleLocation,
-      },
-    },
-    {
-      type: "ImportDeclaration",
-      specifiers: [
-        {
-          type: "ImportSpecifier",
-          local: {
-            type: "Identifier",
-            name: "Configs",
-          },
-          imported: {
-            type: "Identifier",
-            name: "Configs",
-          },
-        },
-      ],
-      source: {
-        type: "Literal",
-        value: props.configsModuleLocation,
-      },
-    },
-
-    {
-      type: "VariableDeclaration",
-      declarations: [
-        {
-          type: "VariableDeclarator",
-          id: {
-            type: "Identifier",
-            name: "PORT",
-          },
-          init: {
-            type: "MemberExpression",
-            computed: false,
-            object: {
-              type: "MemberExpression",
-              computed: false,
-              object: {
-                type: "Identifier",
-                name: "process",
-              },
-              property: {
-                type: "Identifier",
-                name: "env",
-              },
-            },
-            property: {
-              type: "Identifier",
-              name: "PORT",
-            },
-          },
-        },
-      ],
-      kind: "const",
-    },
-    {
-      type: "VariableDeclaration",
-      declarations: [
-        {
-          type: "VariableDeclarator",
-          id: {
-            type: "Identifier",
-            name: "HOST",
-          },
-          init: {
-            type: "MemberExpression",
-            computed: false,
-            object: {
-              type: "MemberExpression",
-              computed: false,
-              object: {
-                type: "Identifier",
-                name: "process",
-              },
-              property: {
-                type: "Identifier",
-                name: "env",
-              },
-            },
-            property: {
-              type: "Identifier",
-              name: "HOST",
-            },
-          },
-        },
-      ],
-      kind: "const",
-    },
-
-    {
-      type: "VariableDeclaration",
-      declarations: [
-        {
-          type: "VariableDeclarator",
-          id: {
-            type: "Identifier",
-            name: "bootstrap",
-          },
-          init: {
-            type: "ArrowFunctionExpression",
-            id: null,
-            params: [],
-            body: {
-              type: "BlockStatement",
-              body: [
-                {
-                  type: "VariableDeclaration",
-                  declarations: [
-                    {
-                      type: "VariableDeclarator",
-                      id: {
-                        type: "Identifier",
-                        name: "configs",
-                      },
-                      init: {
-                        type: "CallExpression",
-                        callee: {
-                          type: "MemberExpression",
-                          computed: false,
-                          object: {
-                            type: "Identifier",
-                            name: "Configs",
-                          },
-                          property: {
-                            type: "Identifier",
-                            name: "fromModule",
-                          },
-                        },
-                        arguments: [
-                          {
-                            type: "AwaitExpression",
-                            argument: {
-                              type: "CallExpression",
-                              callee: {
-                                type: "MemberExpression",
-                                computed: false,
-                                object: {
-                                  type: "Identifier",
-                                  name: "factory",
-                                },
-                                property: {
-                                  type: "Identifier",
-                                  name: "findOn",
-                                },
-                              },
-                              arguments: [
-                                {
-                                  type: "CallExpression",
-                                  callee: {
-                                    type: "MemberExpression",
-                                    computed: false,
-                                    object: {
-                                      type: "NewExpression",
-                                      callee: {
-                                        type: "Identifier",
-                                        name: "URL",
-                                      },
-                                      arguments: [
-                                        {
-                                          type: "Literal",
-                                          value: props.workspaceLocation,
-                                        },
-                                        {
-                                          type: "MemberExpression",
-                                          computed: false,
-                                          object: {
-                                            type: "MemberExpression",
-                                            computed: false,
-                                            object: {
-                                              type: "Identifier",
-                                              name: "import",
-                                            },
-                                            property: {
-                                              type: "Identifier",
-                                              name: "meta",
-                                            },
-                                          },
-                                          property: {
-                                            type: "Identifier",
-                                            name: "url",
-                                          },
-                                        },
-                                      ],
-                                    },
-                                    property: {
-                                      type: "Identifier",
-                                      name: "toString",
-                                    },
-                                  },
-                                  arguments: [],
-                                },
-                                {
-                                  type: "Literal",
-                                  value: "configs",
-                                  raw: '"configs"',
-                                },
-                              ],
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                  kind: "const",
-                },
-                {
-                  type: "VariableDeclaration",
-                  declarations: [
-                    {
-                      type: "VariableDeclarator",
-                      id: {
-                        type: "Identifier",
-                        name: "httpLister",
-                      },
-                      init: {
-                        type: "AwaitExpression",
-                        argument: {
-                          type: "CallExpression",
-                          callee: {
-                            type: "MemberExpression",
-                            computed: false,
-                            object: {
-                              type: "Identifier",
-                              name: "HTTPLister",
-                            },
-                            property: {
-                              type: "Identifier",
-                              name: "fromModule",
-                            },
-                          },
-                          arguments: [
-                            {
-                              type: "AwaitExpression",
-                              argument: {
-                                type: "CallExpression",
-                                callee: {
-                                  type: "Identifier",
-                                  name: "import",
-                                },
-                                arguments: [
-                                  {
-                                    type: "Literal",
-                                    value: props.actionFileLocation,
-                                  },
-                                ],
-                              },
-                            },
-                            {
-                              type: "Identifier",
-                              name: "configs",
-                            },
-                          ],
-                        },
-                      },
-                    },
-                  ],
-                  kind: "const",
-                },
-                {
-                  type: "VariableDeclaration",
-                  declarations: [
-                    {
-                      type: "VariableDeclarator",
-                      id: {
-                        type: "Identifier",
-                        name: "url",
-                      },
-                      init: {
-                        type: "AwaitExpression",
-                        argument: {
-                          type: "CallExpression",
-                          callee: {
-                            type: "MemberExpression",
-                            computed: false,
-                            object: {
-                              type: "Identifier",
-                              name: "httpLister",
-                            },
-                            property: {
-                              type: "Identifier",
-                              name: "listen",
-                            },
-                          },
-                          arguments: [
-                            { type: "Identifier", name: "PORT" },
-                            { type: "Identifier", name: "HOST" },
-                          ],
-                        },
-                      },
-                    },
-                  ],
-                  kind: "const",
-                },
-                {
-                  type: "ExpressionStatement",
-                  expression: {
-                    type: "CallExpression",
-                    callee: {
-                      type: "MemberExpression",
-                      computed: false,
-                      object: {
-                        type: "Identifier",
-                        name: "console",
-                      },
-                      property: {
-                        type: "Identifier",
-                        name: "log",
-                      },
-                    },
-                    arguments: [
-                      {
-                        type: "TemplateLiteral",
-                        quasis: [
-                          {
-                            type: "TemplateElement",
-                            value: {
-                              raw: "Server running at ",
-                            },
-                            tail: false,
-                          },
-                          {
-                            type: "TemplateElement",
-                            value: {
-                              raw: "",
-                            },
-                            tail: true,
-                          },
-                        ],
-                        expressions: [
-                          {
-                            type: "CallExpression",
-                            callee: {
-                              type: "MemberExpression",
-                              computed: false,
-                              object: {
-                                type: "Identifier",
-                                name: "url",
-                              },
-                              property: {
-                                type: "Identifier",
-                                name: "toString",
-                              },
-                            },
-                            arguments: [],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-            generator: false,
-            expression: false,
-            async: true,
-          },
-        },
-      ],
-      kind: "const",
-    },
-    {
-      type: "ExpressionStatement",
-      expression: {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          computed: false,
-          object: {
-            type: "CallExpression",
-            callee: {
-              type: "Identifier",
-              name: "bootstrap",
-            },
-            arguments: [],
-          },
-          property: {
-            type: "Identifier",
-            name: "catch",
-          },
-        },
-        arguments: [
-          {
-            type: "MemberExpression",
-            computed: false,
-            object: {
-              type: "Identifier",
-              name: "console",
-            },
-            property: {
-              type: "Identifier",
-              name: "error",
-            },
-          },
-        ],
-      },
-    },
-  ],
-  sourceType: "module",
-});
+const getTSProgram = (props: ProgramASTProps) =>
+  $doc([
+    $import(props.httpListenerModuleLocation, ["HTTPLister"]),
+    $import(props.configsFactoryModuleLocation, ["factory"]),
+    $import(props.configsModuleLocation, ["Configs"]),
+    $const("PORT", $("process", "env", "PORT")),
+    $const("HOST", $("process", "env", "HOST")),
+    $const(
+      "bootstrap",
+      $asyncArrowFunction([
+        $const(
+          "configs",
+          $call(
+            $("Configs", "fromModule"),
+            $await(
+              $call(
+                $("factory", "findOn"),
+                $call(
+                  $(
+                    $new(
+                      "URL",
+                      $string(props.relativeWorkspaceLocation),
+                      $("import", "meta", "url"),
+                    ),
+                    "toString",
+                  ),
+                ),
+                $string("configs"),
+              ),
+            ),
+          ),
+        ),
+        $const(
+          "httpLister",
+          $await(
+            $call(
+              $("HTTPLister", "fromModule"),
+              $await(
+                $call("import", $string(props.actionRelativeFileLocation)),
+              ),
+              $("configs"),
+            ),
+          ),
+        ),
+        $const(
+          "url",
+          $await($call($("httpLister", "listen"), $("PORT"), $("HOST"))),
+        ),
+        $statement(
+          $call(
+            $("console", "log"),
+            $template`Server running at ${$call($("url", "toString"))}`,
+          ),
+        ),
+      ]),
+    ),
+    $statement($call($($call("bootstrap"), "catch"), $("console", "error"))),
+  ]);
 
 type Props = {
   target: string;
@@ -482,13 +112,13 @@ export const httpListenActionTemplate = (props: Props) => {
     return `./${path.relative(dirname.pathname, path2.pathname)}`;
   };
 
-  const ast = getProgramAST({
+  const ast = getTSProgram({
     httpListenerModuleLocation: relative(httpListenerModuleLocation),
     configsModuleLocation: relative(configsModuleLocation),
     configsFactoryModuleLocation: relative(configsFactoryModuleLocation),
-    actionFileLocation: relative(actionFileLocation),
-    workspaceLocation: `${relative(workspaceLocation)}/`,
+    actionRelativeFileLocation: relative(actionFileLocation),
+    relativeWorkspaceLocation: `${relative(workspaceLocation)}/`,
   });
 
-  return `// @ts-nocheck\n${escodegen.generate(ast)}`;
+  return `// @ts-nocheck\n${render(ast)}`;
 };

--- a/src/gens-templates/typescript-factory/typescript-factory.ts
+++ b/src/gens-templates/typescript-factory/typescript-factory.ts
@@ -1,0 +1,148 @@
+import * as ts from "typescript";
+
+const $expressionOrIdentifier = (value: string | ts.Expression) =>
+  typeof value === "string" ? $indentifier(value) : value;
+export const $indentifier = (name: string) => ts.factory.createIdentifier(name);
+
+type $propertyProps = [
+  ...expressions: (string | ts.Expression)[],
+  name: string | ts.MemberName,
+];
+
+export const $ = (...props: $propertyProps) => {
+  if (props.length === 1 && typeof props[0] === "string")
+    return $indentifier(props[0]);
+  return props.reduce((expression: any, name: any) => {
+    if (!expression) return $expressionOrIdentifier(name);
+    return ts.factory.createPropertyAccessExpression(
+      $expressionOrIdentifier(expression),
+      $indentifier(name),
+    );
+  }) as ts.Expression;
+};
+
+export const $const = (name: string, initializer?: any) =>
+  ts.factory.createVariableStatement(
+    undefined,
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          ts.factory.createIdentifier(name),
+          undefined,
+          undefined,
+          initializer,
+        ),
+      ],
+      ts.NodeFlags.Const,
+    ),
+  );
+
+export const $let = (name: string, initializer: any) =>
+  ts.factory.createVariableStatement(
+    undefined,
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          ts.factory.createIdentifier(name),
+          undefined,
+          undefined,
+          initializer,
+        ),
+      ],
+      ts.NodeFlags.Let,
+    ),
+  );
+
+export const $import = (modelueName: string, exports?: string[]) => {
+  return ts.factory.createImportDeclaration(
+    [],
+    ts.factory.createImportClause(
+      false,
+      undefined,
+      ts.factory.createNamedImports([
+        ...(exports?.map((exportName) =>
+          ts.factory.createImportSpecifier(
+            false,
+            undefined,
+            $indentifier(exportName),
+          ),
+        ) ?? []),
+      ]),
+    ),
+    ts.factory.createStringLiteral(modelueName),
+  );
+};
+
+export const $asyncArrowFunction = (statements: ts.Statement[] = []) => {
+  return ts.factory.createArrowFunction(
+    [ts.factory.createToken(ts.SyntaxKind.AsyncKeyword)],
+    undefined,
+    [],
+    undefined,
+    undefined,
+    ts.factory.createBlock(statements, true),
+  );
+};
+
+export const $await = (expression: ts.Expression) =>
+  ts.factory.createAwaitExpression(expression);
+
+/** @deprecated prefer {@link $await} */
+export const $awaitCall = (
+  expression: string | ts.Expression,
+  ...args: ts.Expression[]
+) => ts.factory.createAwaitExpression($call(expression, ...args));
+
+export const $new = (
+  expression: string | ts.Expression,
+  ...args: ts.Expression[]
+) =>
+  ts.factory.createNewExpression(
+    $expressionOrIdentifier(expression),
+    undefined,
+    args,
+  );
+
+export const $call = (
+  expression: string | ts.Expression,
+  ...args: ts.Expression[]
+) =>
+  ts.factory.createCallExpression(
+    $expressionOrIdentifier(expression),
+    undefined,
+    args,
+  );
+
+export const $string = (value: string) => ts.factory.createStringLiteral(value);
+
+export const $template = (
+  template: TemplateStringsArray,
+  ...substitutions: ts.Expression[]
+) => {
+  return ts.factory.createTemplateExpression(
+    ts.factory.createTemplateHead(template.at(0) ?? ""),
+    substitutions.map((expression, index, arr) => {
+      const isEnd = arr.length - 1 === index;
+      return ts.factory.createTemplateSpan(
+        expression,
+        !isEnd
+          ? ts.factory.createTemplateMiddle(template.at(index + 1) ?? "")
+          : ts.factory.createTemplateTail(template.at(index + 1) ?? ""),
+      );
+    }),
+  );
+};
+
+export const $statement = (expression: ts.Expression) =>
+  ts.factory.createExpressionStatement(expression);
+
+export const $doc = (statements: ts.Statement[]) => {
+  return ts.factory.createSourceFile(
+    statements,
+    ts.factory.createToken(ts.SyntaxKind.EndOfFileToken),
+    ts.NodeFlags.BlockScoped,
+  );
+};
+
+export const render = (sourceFile: ts.SourceFile) =>
+  ts.createPrinter().printFile(sourceFile);

--- a/src/scripts/__snapshots__/make-server-script.spec.ts.snap
+++ b/src/scripts/__snapshots__/make-server-script.spec.ts.snap
@@ -2,16 +2,17 @@
 
 exports[`makeServerScript generates bootstrap script 1`] = `
 "// @ts-nocheck
-import { HTTPLister } from './../../../../../../../http-router/http-listener.js';
-import { factory } from './../../../../../../../configs/modules/factory.js';
-import { Configs } from './../../../../../../../configs/configs.js';
+import { HTTPLister } from "./../../../../../../../http-router/http-listener.js";
+import { factory } from "./../../../../../../../configs/modules/factory.js";
+import { Configs } from "./../../../../../../../configs/configs.js";
 const PORT = process.env.PORT;
 const HOST = process.env.HOST;
 const bootstrap = async () => {
-    const configs = Configs.fromModule(await factory.findOn(new URL('./../../../', import.meta.url).toString(), 'configs'));
-    const httpLister = await HTTPLister.fromModule(await import('./../../../actions.js'), configs);
+    const configs = Configs.fromModule(await factory.findOn(new URL("./../../../", import.meta.url).toString(), "configs"));
+    const httpLister = await HTTPLister.fromModule(await import("./../../../actions.js"), configs);
     const url = await httpLister.listen(PORT, HOST);
-    console.log(\`Server running at \${ url.toString() }\`);
+    console.log(\`Server running at \${url.toString()}\`);
 };
-bootstrap().catch(console.error);"
+bootstrap().catch(console.error);
+"
 `;


### PR DESCRIPTION
## Changes

This pull request improves the template generation for the `http-listen-action` feature. The key changes include:

- Refactored `getProgramAST` to `getTSProgram` for better naming
- Updated relative paths for various module locations, including `httpListenerModuleLocation`, `configsModuleLocation`, `configsFactoryModuleLocation`, `actionRelativeFileLocation`, and `relativeWorkspaceLocation`
- Replaced `escodegen.generate` with `render` for better code generation