### PR TITLE
update-shell-dashboard-with-metrics-client

### DIFF
--- a/src/metric/metrics-client/metrics-client.ts
+++ b/src/metric/metrics-client/metrics-client.ts
@@ -29,7 +29,7 @@ export class MetricsClient {
 
   constructor() {}
 
-  toStateKey(state: State) {
+  private toStateKey(state: State) {
     if (!state.labels) return state.name;
     const labels = state.labels;
     const meta = Object.keys(labels)
@@ -39,7 +39,7 @@ export class MetricsClient {
     return `${state.name}{${meta}}`;
   }
 
-  toUniqueState(state: State) {
+  private toUniqueState(state: State) {
     const stateString = this.toStateKey(state);
     const ref = this.statesRefs.get(stateString);
     if (ref) return ref;
@@ -72,6 +72,15 @@ export class MetricsClient {
         store.toValue(),
       ]),
     );
+  }
+
+  *[Symbol.iterator]() {
+    for (const [state, calculator] of this.db.entries()) {
+      yield {
+        state,
+        value: calculator.toValue(),
+      };
+    }
   }
 }
 

--- a/src/metric/shell-metric-dashboard/shell-metric-dashboard.spec.ts
+++ b/src/metric/shell-metric-dashboard/shell-metric-dashboard.spec.ts
@@ -1,8 +1,16 @@
-import { expect, it, describe } from "bun:test";
+import {
+  expect,
+  it,
+  describe,
+  beforeAll,
+  setSystemTime,
+  afterAll,
+} from "bun:test";
 import { ShellDashboard } from "./shell-metric-dashboard.js";
+import { MetricsClient } from "../metrics-client/metrics-client.js";
 
 describe("Shell Dashboard", () => {
-  it("test 1", () => {
+  it("should render the dashboard correctly with added items and updated stats", () => {
     const shellDashboard = new ShellDashboard();
 
     shellDashboard.addItem("Route GET /__actions");
@@ -23,5 +31,65 @@ describe("Shell Dashboard", () => {
         `Listening on http://localhost:30320/\n` +
         "",
     );
+  });
+
+  describe("when subscribing to metrics client", () => {
+    beforeAll(() => setSystemTime(1000));
+    afterAll(() => setSystemTime());
+
+    it("should update the dashboard based on metrics client updates", () => {
+      const client = new MetricsClient();
+      const shellDashboard = new ShellDashboard();
+
+      shellDashboard.subscribeMetrics(client);
+
+      const logReq = (
+        timestamp: number,
+        method: string,
+        path: string,
+        success: boolean,
+        duration: number,
+        dataSize: number,
+      ) => {
+        setSystemTime(timestamp);
+        if (!success) {
+          client
+            .counter({
+              name: "request_error_counters",
+              labels: { method: method, path: path },
+            })
+            .increment();
+        }
+        client
+          .counter({
+            name: "request_counters",
+            labels: { method: method, path: path },
+          })
+          .increment();
+        client
+          .counter({
+            name: "request_data_transference_bytes",
+            labels: { method: method, path: path },
+          })
+          .increment(dataSize);
+        client
+          .averageBySecond({
+            name: "request_duration_seconds",
+            labels: { method: method, path: path },
+          })
+          .add(duration);
+      };
+
+      logReq(2110, "GET", "/__actions", true, 150, 134_000);
+      logReq(1000, "POST", "/__actions/hello", true, 120, 90_203);
+      logReq(1000, "POST", "/__actions/hello", false, 250, 154_293);
+      logReq(1300, "POST", "/__actions/hello", true, 350, 254_403);
+      logReq(1390, "POST", "/__actions/hello", true, 400, 154_203);
+      logReq(2010, "POST", "/__actions/hello", true, 330, 351_100);
+
+      expect(shellDashboard.render()).toEqual(
+        "GET /__actions        1 reqs 0% (0) errors 150 ms ↑ 130.859 kB\nPOST /__actions/hello 5 reqs 20% (1) errors 305 ms ↔ 980.666 kB\n\n",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Changes

This pull request introduces the following changes:

1. Added an iterator to the `MetricsClient` class, allowing for easy iteration over the stored metric states and their calculated values. This provides a more convenient way to access the metric data, rather than having to manually iterate over the internal database.
2. Added the ability to subscribe to a `MetricsClient` and update the `ShellDashboard` based on the received metrics. The key changes include:
   - Added a `subscribeMetrics` method to the `ShellDashboard` class that takes a `MetricsClient` instance and subscribes to its updates.
   - Implemented a `refreshRenderCallbacks` set to store callback functions that will be called during the `render` method to update the dashboard.
   - Added an `ensureItem` method to the `ShellDashboard` class to ensure that an item exists in the `items` map before updating its stats.
   - Updated the test suite to include a new test case that verifies the dashboard is updated correctly when subscribing to the `MetricsClient`.