### PR TITLE
metrics-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 build: lib/esm
 
 .PHONY: clean
-clean:
+clean: clean~lib/esm
+
+.PHONY: clean_tests
+clean_tests: clean~lib/esm clean~${TMPDIR}__prepare-workspace/
+
+.PHONY: clean~lib/esm
+clean~lib/esm:
 	rm -rf lib/esm
 
 lib/esm:
 	bunx tsc --project tsconfig.esm.json --outDir lib/esm
+
+.PHONY: clean~${TMPDIR}__prepare-workspace/
+clean~${TMPDIR}__prepare-workspace/:
+	rm -rf ${TMPDIR}__prepare-workspace/

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2,7 +2,8 @@ import type { z } from "zod";
 import type { Configs, ConfigsModule } from "../configs/configs.js";
 import actionsList from "../share-actions/share-actions.js";
 
-export const actions = actionsList;
+export const actions: typeof import("../share-actions/share-actions.js").default =
+  actionsList;
 
 type InferZodType<T> = T extends z.ZodType ? z.infer<T> : any;
 type ParameterTypeInferer<T> = T extends (i: infer R) => any ? R : any;

--- a/src/http-router/http-router.ts
+++ b/src/http-router/http-router.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { get } from "@jondotsoy/utils-js/get";
 import { actionsToJson } from "../exporter-actions/exporter-actions.js";
 import { Configs, type ConfigsModule } from "../configs/configs.js";
+import { MetricsClient } from "../metric/metrics-client/metrics-client.js";
 
 const result = async <T>(fn: () => Promise<T>) => {
   try {
@@ -20,12 +21,15 @@ const isZodType = (value: any): value is z.ZodType =>
 
 export class HTTPRouter {
   router: Router<"pass">;
+  metrics: MetricsClient;
 
   constructor(
     actions: Actions,
     readonly configs?: Configs,
   ) {
     const actionsJson = actionsToJson(actions);
+
+    this.metrics = new MetricsClient();
 
     this.router = new Router({
       errorHandling: "pass",
@@ -40,12 +44,49 @@ export class HTTPRouter {
       ],
     });
 
+    configs?.httpSetup(this);
+
     this.router.use("GET", `/__actions`, {
       fetch: () => Response.json({ actions: actionsJson }),
     });
 
     for (const [name, describe] of Object.entries(Actions.describe(actions))) {
+      const metricLabels = {
+        action: name,
+      };
+
+      const requestErrorCountersMetric = this.metrics.counter({
+        name: "request_error_counters",
+        labels: metricLabels,
+      });
+      const requestCountersMetric = this.metrics.counter({
+        name: "request_counters",
+        labels: metricLabels,
+      });
+      const requestDataTransferenceBytesMetric = this.metrics.counter({
+        name: "request_data_transference_bytes",
+        labels: metricLabels,
+      });
+      const requestDurationSecondsMetric = this.metrics.averageBySecond({
+        name: "request_duration_seconds",
+        labels: metricLabels,
+      });
+
       this.router.use("POST", `/__actions/${name}`, {
+        middlewares: [
+          (fetch) => (req) => {
+            const start = Date.now();
+            requestCountersMetric.increment();
+            return Promise.resolve(fetch(req))
+              .catch((err) => {
+                requestErrorCountersMetric.increment();
+                throw err;
+              })
+              .finally(() => {
+                requestDurationSecondsMetric.add(Date.now() - start);
+              });
+          },
+        ],
         fetch: async (req) => {
           const { data } = await result(() => req.json());
           const input = isParser(describe.input)

--- a/src/integrations/__snapshots__/metrics.spec.ts.snap
+++ b/src/integrations/__snapshots__/metrics.spec.ts.snap
@@ -1,0 +1,17 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Metrics Integration should expose metrics endpoint 1`] = `
+"request_error_counters{action="hi"} 0
+request_counters{action="hi"} 0
+request_data_transference_bytes{action="hi"} 0
+request_duration_seconds{action="hi"} NaN
+"
+`;
+
+exports[`Metrics Integration should expose metrics endpoint with data 1`] = `
+"request_error_counters{action="hi"} 0
+request_counters{action="hi"} 1
+request_data_transference_bytes{action="hi"} 0
+request_duration_seconds{action="hi"} 200
+"
+`;

--- a/src/integrations/metrics.spec.ts
+++ b/src/integrations/metrics.spec.ts
@@ -22,7 +22,7 @@ describe("Metrics Integration", () => {
 
     const url = await httpLister.listen();
 
-    console.log('checking url+port for tests', {url})
+    console.log("checking url+port for tests", { url });
 
     const res = await fetch(new URL("/metrics", url));
     expect(res.status).toBe(200);

--- a/src/integrations/metrics.spec.ts
+++ b/src/integrations/metrics.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, setSystemTime, afterAll } from "bun:test";
+import { HTTPLister } from "../http-router/http-listener";
+import { metrics } from "./metrics";
+import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
+
+describe("Metrics Integration", () => {
+  afterAll(() => setSystemTime());
+
+  it("should expose metrics endpoint", async () => {
+    await using cleanupTasks = new CleanupTasks();
+
+    const httpLister = await HTTPLister.fromModule(
+      {
+        hi: () => "hello",
+      },
+      {
+        integrations: [metrics()],
+      },
+    );
+
+    cleanupTasks.add(() => httpLister.close());
+
+    const url = await httpLister.listen();
+
+    const res = await fetch(new URL("/metrics", url));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatchSnapshot();
+  });
+
+  it("should expose metrics endpoint with data", async () => {
+    await using cleanupTasks = new CleanupTasks();
+    setSystemTime(1000);
+
+    const httpLister = await HTTPLister.fromModule(
+      {
+        hi: async () => {
+          setSystemTime(1200);
+          return "hello";
+        },
+      },
+      {
+        integrations: [metrics()],
+      },
+    );
+
+    cleanupTasks.add(() => httpLister.close());
+
+    const url = await httpLister.listen();
+
+    await fetch(new URL("/__actions/hi", url), { method: "POST" });
+
+    const res = await fetch(new URL("/metrics", url));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatchSnapshot();
+  });
+});

--- a/src/integrations/metrics.spec.ts
+++ b/src/integrations/metrics.spec.ts
@@ -22,6 +22,8 @@ describe("Metrics Integration", () => {
 
     const url = await httpLister.listen();
 
+    console.log('checking url+port for tests', {url})
+
     const res = await fetch(new URL("/metrics", url));
     expect(res.status).toBe(200);
     expect(await res.text()).toMatchSnapshot();

--- a/src/integrations/metrics.ts
+++ b/src/integrations/metrics.ts
@@ -1,4 +1,5 @@
 import type { Integration } from "../configs/configs.js";
+import { MetricTextEncoder } from "../metric/metric-text-encoder.js";
 
 export const metrics = (): Integration => {
   return {
@@ -10,12 +11,13 @@ export const metrics = (): Integration => {
             let body = "";
 
             for (const e of httpRouter.metrics) {
-              const l = e.state.labels
-                ? Object.entries(e.state.labels).map(
-                    ([key, value]) => `${key}=${JSON.stringify(value)}`,
-                  )
-                : null;
-              body += `${e.state.name}${l ? `{${l.join(",")}}` : ""} ${e.value}\n`;
+              const metricText = new MetricTextEncoder().encode({
+                name: e.state.name,
+                labels: e.state.labels,
+                value: e.value,
+              });
+
+              body += `${metricText}\n`;
             }
 
             return new Response(body);

--- a/src/integrations/metrics.ts
+++ b/src/integrations/metrics.ts
@@ -1,0 +1,27 @@
+import type { Integration } from "../configs/configs.js";
+
+export const metrics = (): Integration => {
+  return {
+    name: "metrics",
+    hooks: {
+      "http:setup": (httpRouter) => {
+        httpRouter.router.use("ALL", "/metrics", {
+          fetch: () => {
+            let body = "";
+
+            for (const e of httpRouter.metrics) {
+              const l = e.state.labels
+                ? Object.entries(e.state.labels).map(
+                    ([key, value]) => `${key}=${JSON.stringify(value)}`,
+                  )
+                : null;
+              body += `${e.state.name}${l ? `{${l.join(",")}}` : ""} ${e.value}\n`;
+            }
+
+            return new Response(body);
+          },
+        });
+      },
+    },
+  };
+};

--- a/src/metric/metric-text-encoder.spec.ts
+++ b/src/metric/metric-text-encoder.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, test } from "bun:test";
+import { MetricTextEncoder } from "./metric-text-encoder";
+
+describe("MetricTextEncode", () => {
+  it("encode metrics", () => {
+    expect(new MetricTextEncoder().encode({ name: "sd", value: 32 })).toEqual(
+      `sd 32`,
+    );
+    expect(
+      new MetricTextEncoder().encode({
+        name: "name",
+        labels: { foo: "hello" },
+        value: 32,
+      }),
+    ).toEqual(`name{foo="hello"} 32`);
+    expect(
+      new MetricTextEncoder().encode({
+        name: "http_requests_total",
+        labels: { method: "post", code: "200" },
+        value: 1027,
+        timestamp: 1395066363000,
+      }),
+    ).toEqual(
+      `http_requests_total{method="post",code="200"} 1027 1395066363000`,
+    );
+  });
+});

--- a/src/metric/metric-text-encoder.ts
+++ b/src/metric/metric-text-encoder.ts
@@ -1,0 +1,34 @@
+export type Metric = {
+  name: string;
+  labels?: Record<string, string>;
+  value: number;
+  timestamp?: number;
+};
+
+export class MetricTextEncoder {
+  private encodeLabels(labels?: Record<string, string>) {
+    if (!labels) return;
+    return Array.from(
+      Object.entries(labels),
+      ([key, value]) => `${key}=${JSON.stringify(value.toString())}`,
+    ).join(",");
+  }
+
+  encode(inpiut: Metric) {
+    // EBNF format:
+    // metric_name [
+    //   "{" label_name "=" `"` label_value `"` { "," label_name "=" `"` label_value `"` } [ "," ] "}"
+    // ] value [ timestamp ]
+    const metric_name = inpiut.name;
+    const labels = this.encodeLabels(inpiut.labels);
+    const value = inpiut.value;
+    const timestamp = inpiut.timestamp;
+    const parts = {
+      metric_name,
+      labels: labels ? `{${labels}}` : "",
+      value: ` ${value}`,
+      timestamp: timestamp ? ` ${timestamp}` : "",
+    };
+    return `${parts.metric_name}${parts.labels}${parts.value}${parts.timestamp}`;
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -6,5 +6,5 @@
     "allowImportingTsExtensions": false,
     "declaration": true
   },
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules", "**/*.spec.ts", "packages"]
 }


### PR DESCRIPTION
## Changes

This pull request introduces a new metrics integration for the application. The key changes include:

1. **Metrics Client and Request Metrics**: A `MetricsClient` instance has been added to the `HTTPRouter` class, which instruments the request handling with various metrics such as request counters, error counters, data transference bytes, and request duration. This provides better observability and monitoring capabilities for the HTTP router.

2. **HTTP Setup Hook**: A new `"http:setup"` hook has been added to the `Integration` class, which allows integrations to perform setup tasks on the HTTP router. The `Configs` class has been updated to call this new hook when the `httpSetup` method is invoked.

3. **Metrics Integration**: A new integration has been added to expose metrics in the HTTP server. This integration provides a `/metrics` endpoint that returns a Prometheus-compatible metrics output for all registered metrics.

These changes aim to improve the observability and monitoring capabilities of the application by integrating a comprehensive metrics solution.