### PR TITLE
feat(http-router): add metrics to track request data

### DIFF
--- a/src/http-router/http-router.ts
+++ b/src/http-router/http-router.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { get } from "@jondotsoy/utils-js/get";
 import { actionsToJson } from "../exporter-actions/exporter-actions.js";
 import { Configs, type ConfigsModule } from "../configs/configs.js";
+import { MetricsClient } from "../metric/metrics-client/metrics-client.js";
 
 const result = async <T>(fn: () => Promise<T>) => {
   try {
@@ -20,12 +21,15 @@ const isZodType = (value: any): value is z.ZodType =>
 
 export class HTTPRouter {
   router: Router<"pass">;
+  metrics: MetricsClient;
 
   constructor(
     actions: Actions,
     readonly configs?: Configs,
   ) {
     const actionsJson = actionsToJson(actions);
+
+    this.metrics = new MetricsClient();
 
     this.router = new Router({
       errorHandling: "pass",
@@ -40,12 +44,49 @@ export class HTTPRouter {
       ],
     });
 
+    configs?.httpSetup(this);
+
     this.router.use("GET", `/__actions`, {
       fetch: () => Response.json({ actions: actionsJson }),
     });
 
     for (const [name, describe] of Object.entries(Actions.describe(actions))) {
+      const metricLabels = {
+        action: name,
+      };
+
+      const requestErrorCountersMetric = this.metrics.counter({
+        name: "request_error_counters",
+        labels: metricLabels,
+      });
+      const requestCountersMetric = this.metrics.counter({
+        name: "request_counters",
+        labels: metricLabels,
+      });
+      const requestDataTransferenceBytesMetric = this.metrics.counter({
+        name: "request_data_transference_bytes",
+        labels: metricLabels,
+      });
+      const requestDurationSecondsMetric = this.metrics.averageBySecond({
+        name: "request_duration_seconds",
+        labels: metricLabels,
+      });
+
       this.router.use("POST", `/__actions/${name}`, {
+        middlewares: [
+          (fetch) => (req) => {
+            const start = Date.now();
+            requestCountersMetric.increment();
+            return Promise.resolve(fetch(req))
+              .catch((err) => {
+                requestErrorCountersMetric.increment();
+                throw err;
+              })
+              .finally(() => {
+                requestDurationSecondsMetric.add(Date.now() - start);
+              });
+          },
+        ],
         fetch: async (req) => {
           const { data } = await result(() => req.json());
           const input = isParser(describe.input)


### PR DESCRIPTION
## Changes

This pull request adds metrics to the HTTP router to track various request-related data, such as request counts, error counts, data transfer bytes, and request duration. These metrics will help monitor and analyze the performance of the HTTP router.

The key changes include:

- Instantiate a `MetricsClient` instance in the `HTTPRouter` constructor
- Add middleware to the router's POST actions to record request metrics
- Add various metric types (counter, average) to track different request data

These changes will provide valuable insights into the usage and performance of the HTTP router, enabling better monitoring and optimization of the system.