### PR TITLE
add-sse-support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@jondotsoy/flags": "^2.3.0",
         "@jondotsoy/utils-js": "^0.6.0",
         "artur": "^1.2.3",
+        "eventsource": "^3.0.5",
         "jose": "^5.9.6",
         "json-schema-to-zod": "^2.6.0",
         "toml": "^3.0.0",
@@ -110,6 +111,10 @@
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.5", "", { "dependencies": { "eventsource-parser": "^3.0.0" } }, "sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.0", "", {}, "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA=="],
 
     "expect-type": ["expect-type@1.1.0", "", {}, "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@jondotsoy/flags": "^2.3.0",
     "@jondotsoy/utils-js": "^0.6.0",
     "artur": "^1.2.3",
+    "eventsource": "^3.0.5",
     "jose": "^5.9.6",
     "json-schema-to-zod": "^2.6.0",
     "toml": "^3.0.0",

--- a/src/actions-target/actions-target.spec.ts
+++ b/src/actions-target/actions-target.spec.ts
@@ -2,6 +2,8 @@ import { expect, it, mock } from "bun:test";
 import { ActionsTarget } from "./actions-target";
 import { z } from "zod";
 import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
+import { HTTPLister } from "../http-router/http-listener";
+import { expectTypeOf } from "expect-type";
 
 let port = 6767;
 
@@ -18,6 +20,7 @@ it("should call actions", async () => {
   const actionsTarget = new ActionsTarget(server.url, {
     hi: {
       description: undefined,
+      sse: false,
       input: z
         .object({ name: z.string().optional(), metadata: z.record(z.string()) })
         .strict(),
@@ -25,6 +28,7 @@ it("should call actions", async () => {
     },
     foo: {
       description: "foo",
+      sse: false,
       input: z.string(),
       output: z.object({ name: z.string() }).strict(),
     },
@@ -49,6 +53,7 @@ it("should throw error if input is invalid", async () => {
   const actionsTarget = new ActionsTarget(server.url, {
     hi: {
       description: undefined,
+      sse: false,
       input: z
         .object({ name: z.string().optional(), metadata: z.record(z.string()) })
         .strict(),
@@ -56,6 +61,7 @@ it("should throw error if input is invalid", async () => {
     },
     foo: {
       description: "foo",
+      sse: false,
       input: z.string(),
       output: z.object({ name: z.string() }).strict(),
     },
@@ -64,4 +70,83 @@ it("should throw error if input is invalid", async () => {
   await expect(
     actionsTarget.hi({ name: "jhon" } as any),
   ).rejects.toThrowError();
+});
+
+it("should compile actions with input and output", () => {
+  const actionsTarget = new ActionsTarget("http://localhost", {
+    fn1: {
+      description: undefined,
+      sse: false,
+      input: z.string(),
+      output: z.string(),
+    },
+  } as const);
+
+  type targets = ReturnType<typeof actionsTarget.compile>;
+
+  expectTypeOf<targets["fn1"]>().toEqualTypeOf<
+    (arg: string) => Promise<string>
+  >;
+});
+
+it("should compile actions without input", () => {
+  const actionsTarget = new ActionsTarget("http://localhost", {
+    fn1: {
+      description: undefined,
+      sse: false,
+      input: undefined,
+      output: z.string(),
+    },
+  } as const);
+
+  type targets = ReturnType<typeof actionsTarget.compile>;
+
+  expectTypeOf<targets["fn1"]>().toEqualTypeOf<
+    (arg?: unknown) => Promise<string>
+  >;
+});
+
+it("should compile sse actions", () => {
+  const actionsTarget = new ActionsTarget("http://localhost", {
+    fn1: {
+      description: undefined,
+      sse: true,
+      input: undefined,
+      output: z.string(),
+    },
+  } as const);
+
+  type targets = ReturnType<typeof actionsTarget.compile>;
+
+  expectTypeOf<targets["fn1"]>().toEqualTypeOf<
+    (arg?: unknown) => AsyncGenerator<string>
+  >;
+});
+
+it("should call actions from http listener", async () => {
+  await using cleanupTasks = new CleanupTasks();
+
+  const httpLister = HTTPLister.fromModule({
+    fn1: () => "ok",
+    *fn2() {
+      yield 1;
+      yield 2;
+    },
+  });
+  cleanupTasks.add(() => httpLister.close());
+
+  const url = await httpLister.listen();
+
+  const actionsTarget = new ActionsTarget(
+    new URL(url),
+    (await (await fetch(new URL("/__actions", url))).json()).actions,
+  );
+
+  const targets = actionsTarget.compile();
+
+  expect(targets.fn2.prototype).toEqual(async function* () {}.prototype);
+
+  const res = targets.fn2() as AsyncGenerator<any>;
+
+  expect(await Array.fromAsync(res)).toEqual([1, 2]);
 });

--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 import { expectTypeOf } from "expect-type";
 import { Actions, defineAction } from "./actions";
+import type { actions } from "actioman";
 
 describe("Actions", () => {
   it("should create a new action", () => {
@@ -63,5 +64,40 @@ describe("Actions", () => {
 
     expectTypeOf<callActionInput>().toEqualTypeOf<{ name: string }>;
     expectTypeOf<extractedResponseType>().toEqualTypeOf<string>;
+  });
+
+  it("should infer sse handler", () => {
+    const action = defineAction({
+      sse: true,
+      output: z.string(),
+      *handler() {
+        yield "";
+      },
+    });
+
+    type Action = typeof action;
+    type callActionInput = ReturnType<Action["handler"]>;
+
+    expectTypeOf<callActionInput>().toEqualTypeOf<
+      Generator<string> | AsyncGenerator<string>
+    >;
+  });
+
+  it("should infer sse from module", () => {
+    const actions = Actions.fromModule({
+      *f1() {
+        yield "ok";
+      },
+      async *f2() {
+        yield "ok";
+      },
+      f3: () => "ok",
+      f4: async () => "ok",
+    });
+
+    expect(Actions.describe(actions!).f1.sse).toBeTrue();
+    expect(Actions.describe(actions!).f2.sse).toBeTrue();
+    expect(Actions.describe(actions!).f3.sse).toBeFalse();
+    expect(Actions.describe(actions!).f4.sse).toBeFalse();
   });
 });

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -4,28 +4,52 @@ import { get } from "@jondotsoy/utils-js/get";
 import actionsList from "../share-actions/share-actions.js";
 
 export const actions = actionsList;
+const GeneratorFunction = function* () {}.constructor;
+const AsyncGeneratorFunction = async function* () {}.constructor;
 
 type InferZodType<T> = T extends z.ZodType ? z.infer<T> : any;
 type ParameterTypeInferer<T> = T extends (i: infer R) => any ? R : any;
+type Handler<
+  InputType = any,
+  ResultType = any,
+  SSE extends boolean = any,
+> = SSE extends true
+  ? (
+      input: InferZodType<InputType>,
+    ) =>
+      | Generator<InferZodType<ResultType>>
+      | AsyncGenerator<InferZodType<ResultType>>
+  : (
+      input: InferZodType<InputType>,
+    ) => InferZodType<ResultType> | Promise<InferZodType<ResultType>>;
 
-export type Action<InputType = any, ResultType = any, T = any> = {
+export type Action<
+  InputType = any,
+  ResultType = any,
+  SSE extends boolean = false,
+  T = any,
+> = {
   description?: string;
   input?: InputType;
   output?: ResultType;
-  handler: (
-    input: InferZodType<InputType>,
-  ) => InferZodType<ResultType> | Promise<InferZodType<ResultType>>;
+  sse?: SSE;
+  handler: Handler<InputType, ResultType, SSE>;
 };
 
-export const defineAction = <I = any, R = any>(
-  action: Action<I, R>,
-): Action<I, R> => action;
+export const defineAction = <I = any, R = any, SSE extends boolean = false>(
+  action: Action<I, R, SSE>,
+): Action<I, R, SSE> => action;
 
 export const actionFromModule = (module: any) => {
   const handlerFn = get.function(module) as
     | undefined
     | ((...args: any[]) => any);
-  if (handlerFn) return defineAction({ handler: handlerFn });
+  if (handlerFn) {
+    const isGenerator =
+      handlerFn instanceof GeneratorFunction ||
+      handlerFn instanceof AsyncGeneratorFunction;
+    return defineAction({ sse: isGenerator, handler: handlerFn });
+  }
   const handlerObj = get.record(module);
   if (!handlerObj) return null;
   const handler = get.function(handlerObj, "handler") as
@@ -67,7 +91,7 @@ export class Actions<ActionsDefinitions extends Record<string, Action> = any> {
 
     if (!isRecord) return null;
 
-    const actionDefinitions: Record<string, Action> = {};
+    const actionDefinitions: Record<string, Action<any, any, any>> = {};
 
     for (const [moduleName, handler] of Object.entries(module)) {
       const definition = actionFromModule(handler);

--- a/src/exporter-actions/__snapshots__/exporter-actions.spec.ts.snap
+++ b/src/exporter-actions/__snapshots__/exporter-actions.spec.ts.snap
@@ -19,52 +19,7 @@ exports[`actionsToJson should export actions to JSON 1`] = `
     "output": {
       "type": "string",
     },
+    "sse": undefined,
   },
 }
-`;
-
-exports[`importActionsFromJson should import actions from JSON 1`] = `
-"import { z } from "zod";
-
-"
-`;
-
-exports[`importActionsFromJson should import actions from JSON with different types 1`] = `
-"import { z } from "zod";
-
-export const hi = {
-  description: "Say hello",
-  target: "http://localhost:9080/__actions/hi"
-  input: z.object({ "name": z.string() }),
-  output: z.string(),
-} as const;
-
-export const foo = {
-  description: undefined,
-  target: "http://localhost:9080/__actions/foo"
-  input: null,
-  output: null,
-} as const;
-
-"
-`;
-
-exports[`should create ActionsDocument from HTTP server 1`] = `
-"// @ts-nocheck
-import { z } from "zod";
-import { ActionsTarget } from "./node_modules/actions-target/actions-target.js";
-const createActionsTarget = () => new ActionsTarget("http://localhost:43112/__actions", {
-    hi: {
-        description: undefined,
-        input: z.object({ "name": z.string().optional(), "metadata": z.record(z.string()) }).strict(),
-        output: undefined
-    },
-    foo: {
-        description: "foo",
-        input: z.string(),
-        output: z.object({ "name": z.string() }).strict()
-    }
-}).compile();
-export default createActionsTarget;
-"
 `;

--- a/src/exporter-actions/dtos/actions-definitions-json.dto.ts
+++ b/src/exporter-actions/dtos/actions-definitions-json.dto.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const ActionDefinitionJson = z.object({
   description: z.string().nullable().optional(),
+  sse: z.boolean().optional(),
   input: z.object({}).nullable().optional(),
   output: z.object({}).nullable().optional(),
 });

--- a/src/exporter-actions/exporter-actions.ts
+++ b/src/exporter-actions/exporter-actions.ts
@@ -103,6 +103,7 @@ export const actionsToJson = (actions: Actions): ActionsDefinitionsJsonDTO => {
         name,
         {
           description: definition.description ?? null,
+          sse: definition.sse,
           input: definition.input
             ? zodToJsonSchema(definition.input, { target: undefined })
             : null,

--- a/src/http-router/__snapshots__/http-listener.spec.ts.snap
+++ b/src/http-router/__snapshots__/http-listener.spec.ts.snap
@@ -1,5 +1,5 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HTTPLister integration tests should return 200 for /__actions 1`] = `"{"actions":{"hi":{"description":null,"input":null,"output":null}}}"`;
+exports[`HTTPLister integration tests should return 200 for /__actions 1`] = `"{"actions":{"hi":{"description":null,"sse":false,"input":null,"output":null}}}"`;
 
 exports[`HTTPLister integration tests should return 200 for /__actions/hi 1`] = `""ok""`;

--- a/src/http-router/__snapshots__/http-router.spec.ts.snap
+++ b/src/http-router/__snapshots__/http-router.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`HTTPRouter should handle actions with zod validation 1`] = `
       "description": null,
       "input": null,
       "output": null,
+      "sse": false,
     },
     "taz": {
       "description": null,
@@ -26,3 +27,14 @@ exports[`HTTPRouter should handle actions with zod validation 1`] = `
 `;
 
 exports[`HTTPRouter should handle actions without zod validation 1`] = `"ok"`;
+
+exports[`HTTPRouter should handle sse actions 1`] = `
+"data: {"a":1}
+
+data: "2"
+
+event: close
+data: true
+
+"
+`;

--- a/src/http-router/__snapshots__/http2-listener.spec.ts.snap
+++ b/src/http-router/__snapshots__/http2-listener.spec.ts.snap
@@ -1,5 +1,5 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`async HTTP2Lister should return 200 for /__actions 1`] = `"{"actions":{"hi":{"description":null,"input":null,"output":null}}}"`;
+exports[`async HTTP2Lister should return 200 for /__actions 1`] = `"{"actions":{"hi":{"description":null,"sse":false,"input":null,"output":null}}}"`;
 
-exports[`async HTTP2Lister should return 200 for /__actions without ssl 1`] = `"{"actions":{"hi":{"description":null,"input":null,"output":null}}}"`;
+exports[`async HTTP2Lister should return 200 for /__actions without ssl 1`] = `"{"actions":{"hi":{"description":null,"sse":false,"input":null,"output":null}}}"`;

--- a/src/http-router/http-listener.ts
+++ b/src/http-router/http-listener.ts
@@ -66,7 +66,7 @@ export class HTTPLister {
     };
 
     const portToListen = port ?? (await findNextPort());
-    const hostnameToListen = hostname ?? "localhost";
+    const hostnameToListen = hostname ?? "::";
 
     const url = await new Promise<URL>((resolve) => {
       this.server.listen(portToListen, hostnameToListen, () => {

--- a/src/http-router/http-router.spec.ts
+++ b/src/http-router/http-router.spec.ts
@@ -51,4 +51,26 @@ describe("HTTPRouter", () => {
     expect(res?.headers.get("Content-Type")).toStartWith("application/json");
     expect(await res?.json()).toMatchSnapshot();
   });
+
+  it("should handle sse actions", async () => {
+    const httpRouter = HTTPRouter.fromModule({
+      async *f1() {
+        yield { a: 1 };
+        yield "2";
+      },
+    });
+
+    const res = await httpRouter.router.fetch(
+      new Request("http://localhost/__actions/f1", { method: "GET" }),
+    );
+    const controlCacheHeader = res?.headers.get("Cache-Control");
+    const contentTypeHeader = res?.headers.get("Content-Type");
+    const statusCode = res?.status;
+    const body = await res?.text();
+
+    expect(statusCode).toEqual(200);
+    expect(controlCacheHeader).toEqual("no-cache");
+    expect(contentTypeHeader).toEqual("text/event-stream");
+    expect(body).toMatchSnapshot();
+  });
 });

--- a/src/http-router/http-router.ts
+++ b/src/http-router/http-router.ts
@@ -1,5 +1,5 @@
 import { Router } from "artur";
-import { Actions } from "../actions/actions.js";
+import { Actions, type Action } from "../actions/actions.js";
 import { z } from "zod";
 import { get } from "@jondotsoy/utils-js/get";
 import { result } from "@jondotsoy/utils-js/result";
@@ -10,6 +10,19 @@ const isParser = (value: any): value is { parse: (value: any) => any } =>
   get.function(value, "parse") !== undefined;
 const isZodType = (value: any): value is z.ZodType =>
   value instanceof z.ZodType;
+const isSSEAction = (
+  action: Action<any, any, any>,
+): action is Action<any, any, true> => action.sse === true;
+
+class EventStreamDataEncoder {
+  encode(data: { id?: string; event?: string; data: any }) {
+    const l = [];
+    if (data.id) l.push(`id: ${data.id}`);
+    if (data.event) l.push(`event: ${data.event}`);
+    l.push(`data: ${JSON.stringify(data.data)}`);
+    return new TextEncoder().encode(l.join("\n") + "\n\n");
+  }
+}
 
 export class HTTPRouter {
   router: Router<"pass">;
@@ -38,20 +51,64 @@ export class HTTPRouter {
     });
 
     for (const [name, describe] of Object.entries(Actions.describe(actions))) {
-      this.router.use("POST", `/__actions/${name}`, {
+      const isSSE = isSSEAction(describe);
+      const method = isSSE ? "GET" : "POST";
+      this.router.use(method, `/__actions/${name}`, {
         fetch: async (req) => {
-          const [, data] = await result(() => req.json());
-          const input = isParser(describe.input)
-            ? describe.input.parse(data)
-            : null;
-          const resultDescribe = await describe.handler(input);
-          const output = isParser(describe.output)
-            ? describe.output.parse(resultDescribe)
-            : resultDescribe;
-          return Response.json(output);
+          if (isSSE) return this.sseHandler(describe, req);
+          return this.handler(describe, req);
         },
       });
     }
+  }
+
+  private async sseHandler(action: Action<any, any, true>, req: Request) {
+    const url = new URL(req.url);
+    const inputSearchParams = url.searchParams.get("input") ?? null;
+    const [, data] = await result(() =>
+      inputSearchParams ? JSON.parse(inputSearchParams) : null,
+    );
+    const input = isParser(action.input) ? action.input.parse(data) : null;
+    const resultAction = await action.handler(input);
+    const body = new ReadableStream<Uint8Array>({
+      pull: async (ctrl) => {
+        const { done, value } = await resultAction.next();
+
+        if (done) {
+          ctrl.enqueue(
+            new EventStreamDataEncoder().encode({
+              event: "close",
+              data: true,
+            }),
+          );
+          return ctrl.close();
+        }
+
+        const output = isParser(action.output)
+          ? action.output.parse(value)
+          : value;
+
+        ctrl.enqueue(new EventStreamDataEncoder().encode({ data: output }));
+      },
+    });
+    return new Response(body, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  }
+
+  private async handler(action: Action<any, any, any>, req: Request) {
+    const [, data] = await result(() => req.json());
+    const input = isParser(action.input) ? action.input.parse(data) : null;
+    const resultDescribe = await action.handler(input);
+    const output = isParser(action.output)
+      ? action.output.parse(resultDescribe)
+      : resultDescribe;
+    return Response.json(output);
   }
 
   static fromModule(module: unknown, configs?: ConfigsModule) {


### PR DESCRIPTION
## Changes

This pull request adds support for Server-Sent Events (SSE) in the application. The key changes include:

1. Introduce a new `Handler` type that represents both synchronous and asynchronous SSE handlers.
2. Update the `defineAction` function to accept an optional `sse` parameter to indicate if the handler is an SSE handler.
3. Modify the `actionFromModule` function to detect if the handler is a generator function (synchronous or asynchronous) and set the `sse` flag accordingly.
4. Add support for handling SSE actions in the `HTTPRouter` class, including a new `sseHandler` method and updates to the `HTTPRouter.fromModule` method.
5. Add a new `EventStreamDataEncoder` class to encode the SSE data.
6. Add a new `sse` option to the actions definition in the `ActionsTarget` class, allowing users to specify whether the action should use SSE for the response.
7. Update the `ActionsTarget` class to support actions with optional input.
8. Add new test cases to verify the SSE handler inference and behavior.

These changes allow the library to better support a wider range of action definitions, including those that emit events over time (SSE) in addition to the existing synchronous and asynchronous actions.