### PR TITLE
improve-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+CONTAINER_TEST_HASH := $(shell cat compose.yml | shasum -a 256 | awk '{print $$1}')
+TEST_ARG :=
+
 build: lib/esm
 
 .PHONY: clean
@@ -6,3 +9,17 @@ clean:
 
 lib/esm:
 	bunx tsc --project tsconfig.esm.json --outDir lib/esm
+
+/tmp/.process.${CONTAINER_TEST_HASH}.actioman-test.json:
+	docker compose up test -d --build
+	docker compose ps test --format json | jq > $@
+
+.PHONY: clean@docker
+clean@docker:
+	rm -rf /tmp/.process.${CONTAINER_TEST_HASH}.actioman-test.json
+
+.PHONY: test@docker
+test@docker: /tmp/.process.${CONTAINER_TEST_HASH}.actioman-test.json
+	$(eval CONTAINER_TEST_ID=$(shell cat /tmp/.process.${CONTAINER_TEST_HASH}.actioman-test.json | jq '.Name' -r))
+	docker exec ${CONTAINER_TEST_ID} bash -i -c "bun i"
+	docker exec ${CONTAINER_TEST_ID} bash -i -c "bun test ${TEST_ARG}"

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@jondotsoy/utils-js": "^0.6.0",
         "artur": "^1.2.3",
         "eventsource": "^3.0.5",
+        "fetch-h2": "^3.0.2",
         "jose": "^5.9.6",
         "json-schema-to-zod": "^2.6.0",
         "toml": "^3.0.0",
@@ -64,9 +65,13 @@
 
     "@types/serve-static": ["@types/serve-static@1.15.7", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw=="],
 
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "already": ["already@2.2.1", "", {}, "sha512-qk6RIVMS/R1yTvBzfIL1T76PsIL7DIVCINoLuFw2YXKLpLtsTobqdChMs8m3OhuPS3CEE3+Ra5ibYiqdyogbsQ=="],
 
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
 
@@ -81,6 +86,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.3", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "get-intrinsic": "^1.2.6" } }, "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA=="],
+
+    "callguard": ["callguard@2.0.0", "", {}, "sha512-I3nd+fuj20FK1qu00ImrbH+II+8ULS6ioYr9igqR1xyqySoqc3DiHEyUM0mkoAdKeLGg2CtGnO8R3VRQX5krpQ=="],
 
     "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
@@ -120,6 +127,8 @@
 
     "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
 
+    "fetch-h2": ["fetch-h2@3.0.2", "", { "dependencies": { "@types/tough-cookie": "^4.0.0", "already": "^2.2.1", "callguard": "^2.0.0", "get-stream": "^6.0.1", "through2": "^4.0.2", "to-arraybuffer": "^1.0.1", "tough-cookie": "^4.0.0" } }, "sha512-Lo6UPdMKKc9Ond7yjG2vq0mnocspOLh1oV6+XZdtfdexacvMSz5xm3WoQhTAdoR2+UqPlyMNqcqfecipoD+l/A=="],
+
     "finalhandler": ["finalhandler@1.3.1", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "2.4.1", "parseurl": "~1.3.3", "statuses": "2.0.1", "unpipe": "~1.0.0" } }, "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
@@ -131,6 +140,8 @@
     "get-intrinsic": ["get-intrinsic@1.2.7", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "function-bind": "^1.1.2", "get-proto": "^1.0.0", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -180,11 +191,21 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
+
+    "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -206,9 +227,17 @@
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "through2": ["through2@4.0.2", "", { "dependencies": { "readable-stream": "3" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
+
+    "to-arraybuffer": ["to-arraybuffer@1.0.1", "", {}, "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
+
+    "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
 
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
@@ -216,9 +245,15 @@
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
+    "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
+
     "urlpattern-polyfill": ["urlpattern-polyfill@10.0.0", "", {}, "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@jondotsoy/utils-js": "^0.6.0",
     "artur": "^1.2.3",
     "eventsource": "^3.0.5",
+    "fetch-h2": "^3.0.2",
     "jose": "^5.9.6",
     "json-schema-to-zod": "^2.6.0",
     "toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "fmt": "prettier -w .",
     "lint": "prettier -c .",
-    "prepack": "make clean build"
+    "prepack": "rm -rf lib/esm && bunx tsc --project tsconfig.esm.json --outDir lib/esm"
   },
   "bin": "./lib/esm/cli/actioman.js",
   "devDependencies": {

--- a/src/cli/cmds/add.spec.ts
+++ b/src/cli/cmds/add.spec.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { HTTPLister } from "../../http-router/http-listener.js";
 import { defineAction } from "../../actions/actions";
 import { z } from "zod";
 import * as fs from "fs/promises";
 import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 import { PrepareWorkspace } from "../utils/prepare-workspace.js";
+import { cleanHistoryPids } from "../../shell/shell.js";
 
 let port = 9080;
 
 describe("add", async () => {
+  afterEach(() => cleanHistoryPids());
+
   it(
     "should add remote actions and use them",
     async () => {

--- a/src/cli/cmds/add.spec.ts
+++ b/src/cli/cmds/add.spec.ts
@@ -6,6 +6,8 @@ import * as fs from "fs/promises";
 import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 import { PrepareWorkspace } from "../utils/prepare-workspace.js";
 
+let port = 9080;
+
 describe("add", async () => {
   it(
     "should add remote actions and use them",
@@ -25,7 +27,7 @@ describe("add", async () => {
         sum: ({ a, b }: { a: number; b: number }) => 3,
         add: ({ a, b }: { a: number; b: number }) => 3,
       });
-      const serviceUrl = await httpLocation.listen();
+      const serviceUrl = await httpLocation.listen(port++);
 
       await $`npx actioman add foo ${serviceUrl.toString()}`;
       await $`npx actioman add taz ${serviceUrl.toString()}`;

--- a/src/cli/cmds/install.spec.ts
+++ b/src/cli/cmds/install.spec.ts
@@ -5,6 +5,8 @@ import { HTTPLister } from "../../http-router/http-listener.js";
 import { defineAction } from "../../actions/actions.js";
 import { z } from "zod";
 
+let port = 10080;
+
 describe("install", async () => {
   it(
     "should install without errors",
@@ -33,7 +35,7 @@ describe("install", async () => {
           handler: async ({ name }) => `hello ${name}!`,
         }),
       });
-      const serviceUrl = await httpLocation.listen();
+      const serviceUrl = await httpLocation.listen(port++);
 
       await $work`npx actioman add "my action" ${serviceUrl.toString()}`;
 

--- a/src/cli/cmds/install.spec.ts
+++ b/src/cli/cmds/install.spec.ts
@@ -1,17 +1,20 @@
-import { describe, it } from "bun:test";
+import { afterEach, describe, it } from "bun:test";
 import { PrepareWorkspace } from "../utils/prepare-workspace.js";
 import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 import { HTTPLister } from "../../http-router/http-listener.js";
 import { defineAction } from "../../actions/actions.js";
 import { z } from "zod";
+import { cleanHistoryPids } from "../../shell/shell.js";
 
 let port = 10080;
 
 describe("install", async () => {
+  afterEach(() => cleanHistoryPids());
+
   it(
     "should install without errors",
     async () => {
-      const { $: $work } = await PrepareWorkspace.setup();
+      const { $: $work } = await PrepareWorkspace.setup({ name: "install" });
       await $work`
       npx actioman install
     `;
@@ -21,10 +24,13 @@ describe("install", async () => {
 });
 
 describe("install", async () => {
+  afterEach(() => cleanHistoryPids());
+
   it(
     "should install remote actions and use them",
     async () => {
-      const { $: $work } = await PrepareWorkspace.setup();
+      console.log("lo");
+      const { $: $work } = await PrepareWorkspace.setup({ name: "install" });
       await using cleanupTasks = new CleanupTasks();
       cleanupTasks.add(() => httpLocation.close());
 
@@ -35,9 +41,12 @@ describe("install", async () => {
           handler: async ({ name }) => `hello ${name}!`,
         }),
       });
+      console.log("listening");
       const serviceUrl = await httpLocation.listen(port++);
+      console.log("🚀 ~ serviceUrl:", serviceUrl);
 
-      await $work`npx actioman add "my action" ${serviceUrl.toString()}`;
+      console.log(`npx actioman add "my action" "${serviceUrl.toString()}"`);
+      await $work`npx actioman add "my action" "${serviceUrl.toString()}"`;
 
       await $work`
       npx actioman install

--- a/src/cli/cmds/serve.spec.ts
+++ b/src/cli/cmds/serve.spec.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { PrepareWorkspace } from "../utils/prepare-workspace";
 import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 import { DEFAULT_CERT } from "../../http-router/DEFAULT_CERT";
+import { cleanHistoryPids } from "../../shell/shell";
 
 describe("serve", () => {
+  afterEach(() => cleanHistoryPids());
+
   it(
     "should start a server and return 404 if the requested resource is not found",
     async () => {

--- a/src/cli/utils/prepare-workspace.spec.ts
+++ b/src/cli/utils/prepare-workspace.spec.ts
@@ -1,7 +1,10 @@
-import { describe, it } from "bun:test";
+import { afterEach, describe, it } from "bun:test";
 import { PrepareWorkspace } from "./prepare-workspace";
+import { cleanHistoryPids } from "../../shell/shell";
 
 describe("PrepareWorkspace", () => {
+  afterEach(() => cleanHistoryPids());
+
   it(
     "should setup a workspace",
     async () => {

--- a/src/exporter-actions/__snapshots__/exporter-actions.spec.ts.snap
+++ b/src/exporter-actions/__snapshots__/exporter-actions.spec.ts.snap
@@ -23,3 +23,49 @@ exports[`actionsToJson should export actions to JSON 1`] = `
   },
 }
 `;
+
+exports[`should create ActionsDocument from HTTP server 1`] = `
+"// @ts-nocheck
+import { z } from "zod";
+import { ActionsTarget } from "./node_modules/actions-target/actions-target.js";
+const createActionsTarget = () => new ActionsTarget("http://localhost:11080/__actions", {
+    hi: {
+        description: undefined,
+        input: z.object({ "name": z.string().optional(), "metadata": z.record(z.string()) }).strict(),
+        output: undefined
+    },
+    foo: {
+        description: "foo",
+        input: z.string(),
+        output: z.object({ "name": z.string() }).strict()
+    }
+}).compile();
+export default createActionsTarget;
+"
+`;
+
+exports[`importActionsFromJson should import actions from JSON 1`] = `
+"import { z } from "zod";
+
+"
+`;
+
+exports[`importActionsFromJson should import actions from JSON with different types 1`] = `
+"import { z } from "zod";
+
+export const hi = {
+  description: "Say hello",
+  target: "http://localhost:9080/__actions/hi"
+  input: z.object({ "name": z.string() }),
+  output: z.string(),
+} as const;
+
+export const foo = {
+  description: undefined,
+  target: "http://localhost:9080/__actions/foo"
+  input: null,
+  output: null,
+} as const;
+
+"
+`;

--- a/src/exporter-actions/exporter-actions.spec.ts
+++ b/src/exporter-actions/exporter-actions.spec.ts
@@ -10,6 +10,8 @@ import type { ActionsDefinitionsJsonDTO } from "./dtos/actions-definitions-json.
 import { HTTPLister } from "../http-router/http-listener";
 import { CleanupTasks } from "@jondotsoy/utils-js/cleanuptasks";
 
+let port = 11080;
+
 describe("actionsToJson", () => {
   it("should export actions to JSON", () => {
     const actions = new Actions({
@@ -84,7 +86,7 @@ it("should create ActionsDocument from HTTP server", async () => {
       handler: () => "ok",
     },
   });
-  const url = await httpLister.listen(43112);
+  const url = await httpLister.listen(port++);
 
   const actionsDocument = await ActionsDocument.fromHTTPServer(
     url,

--- a/src/exporter-actions/exporter-actions.ts
+++ b/src/exporter-actions/exporter-actions.ts
@@ -4,6 +4,7 @@ import type { ActionsDefinitionsJsonDTO } from "./dtos/actions-definitions-json.
 import { get } from "@jondotsoy/utils-js/get";
 import jsonSchemaToZod from "json-schema-to-zod";
 import { actionDocumentTemplate } from "../gens-templates/action-document.template.js";
+import { fetch } from "fetch-h2";
 
 /** @deprecated by {@link actionDocumentTemplate} */
 const templateAction = (
@@ -83,7 +84,7 @@ export class ActionsDocument {
     actionsTargetModuleLocation?: string,
   ) {
     const targetUrl = new URL("./__actions", url);
-    const res = await fetch(targetUrl);
+    const res = await fetch(targetUrl.toString());
     const b = await res.json();
     const actionsJson = b.actions;
     return new ActionsDocument(

--- a/src/http-router/http2-listener.spec.ts
+++ b/src/http-router/http2-listener.spec.ts
@@ -5,6 +5,8 @@ import * as http2 from "http2";
 import { DEFAULT_CERT } from "./DEFAULT_CERT.js";
 import { DEFAULT_KEY } from "./DEFAULT_KEY.js";
 
+let port = 8080;
+
 describe("async HTTP2Lister", () => {
   it("should return 200 for /__actions", async () => {
     await using cleanupTasks = new CleanupTasks();
@@ -24,7 +26,7 @@ describe("async HTTP2Lister", () => {
     );
     cleanupTasks.add(() => http2Lister.close());
 
-    const url = await http2Lister.listen();
+    const url = await http2Lister.listen(port++);
 
     const client = http2.connect(url, { ca: DEFAULT_CERT });
     cleanupTasks.add(() => client.close());
@@ -65,7 +67,7 @@ describe("async HTTP2Lister", () => {
     });
     cleanupTasks.add(() => http2Lister.close());
 
-    const url = await http2Lister.listen();
+    const url = await http2Lister.listen(port++);
 
     const client = http2.connect(url);
     cleanupTasks.add(() => client.close());

--- a/src/http-router/integrations/auth.spec.ts
+++ b/src/http-router/integrations/auth.spec.ts
@@ -4,7 +4,7 @@ import { HTTPLister } from "../http-listener.js";
 import { auth } from "./auth.js";
 import { TEST_RUN_EXPERIMENTAL } from "../../constants/TEST_RUN_EXPERIMENTAL.js";
 
-let test_port = 33321;
+let test_port = 12080;
 
 describe("auth integration", () => {
   it("should return 401 if there is no token", async () => {

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -126,10 +126,14 @@ export class ShellConstructor<T> {
     const stderrWritableWriter = this.stderrWritable.getWriter();
 
     const subprocess = spawn("sh", ["-c", cmd], {
-      signal: abortController.signal,
+      // signal: abortController.signal,
       stdio: ["pipe", "pipe", "pipe"],
       env: env,
       cwd: cwd,
+    });
+
+    abortController.signal.addEventListener("abort", () => {
+      subprocess.kill(1);
     });
 
     subprocess.stdout.addListener("data", (chunk: Uint8Array) => {

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -1,5 +1,15 @@
 import { spawn, spawnSync } from "child_process";
 
+export const shellHistoryPids = new Set<number>();
+
+export const cleanHistoryPids = async () => {
+  for (const shellHistoryPid of shellHistoryPids) {
+    try {
+      spawnSync(`kill ${shellHistoryPid}`);
+    } catch {}
+  }
+};
+
 type ShellConstructorOutput = "codeStatus" | "text" | "pipe";
 
 type ShellConstructorOptions = {
@@ -131,6 +141,8 @@ export class ShellConstructor<T> {
       env: env,
       cwd: cwd,
     });
+
+    if (subprocess.pid) shellHistoryPids.add(subprocess.pid);
 
     abortController.signal.addEventListener("abort", () => {
       subprocess.kill(1);

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -6,5 +6,5 @@
     "allowImportingTsExtensions": false,
     "declaration": true
   },
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules", "**/*.spec.ts", "packages"]
 }


### PR DESCRIPTION
## Changes

This pull request includes the following improvements and bug fixes:

1. Exclude the 'packages' directory from the `tsconfig.esm.json` file to prevent it from being included in the TypeScript compilation process, improving the overall build performance.
2. Add support for dynamic port assignment when starting the HTTP server in the `add` and `install` commands, allowing for running multiple tests in parallel without port conflicts.
3. Improve the handling of URLs in the HTTP router tests by using `new URL()` to construct URLs instead of hardcoding the port number, and incrementing the port number for each test to avoid conflicts.
4. Add a new set of actions (`hi` and `foo`) to the exporter and update the corresponding snapshots.
5. Add a new target to the Makefile that allows running the tests in a Docker container, making it easier to run the tests in a consistent environment.
6. Add the `fetch-h2` library to the project's dependencies to improve the performance and functionality of the application's network communication, particularly in scenarios where HTTP/2 is supported.
7. Update the `ActionsDocument` constructor to use the `fetch-h2` library for fetching the actions target URL, improving the reliability and performance of the actions fetching process.
8. Replace the `make clean build` script with a more targeted TypeScript build command to ensure that the `lib/esm` directory is properly cleaned up before the new build is generated, improving the overall build reliability and consistency.
9. Add an event listener to the AbortController signal to handle the case where the subprocess needs to be terminated, ensuring that the subprocess is properly killed.
10. Add the subprocess pid to a history set when a new shell subprocess is created, and add a `cleanHistoryPids` function to clean up the history by killing all the subprocess pids in the history set when the tests are finished.

These changes improve the overall quality, performance, and maintainability of the project.