### PR TITLE
update-release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 on:
-  push: {}
+  push:
+    branches:
+      - develop
 
 jobs:
   release:
@@ -11,3 +13,32 @@ jobs:
       pull-requests: write
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  prepare:
+    needs:
+      - release
+    runs-on: ubuntu-latest
+    if: !needs.release.outputs.release_created
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: build version file
+        run: |
+          make build_version_file
+      - name: commit version change
+        continue-on-error: true
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add src/actioman-version.ts
+          git commit -m "chore: upgrade actioman-version.ts"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ test@docker: /tmp/.process.${CONTAINER_TEST_HASH}.actioman-test.json
 	$(eval CONTAINER_TEST_ID=$(shell cat /tmp/.process.${CONTAINER_TEST_HASH}.actioman-test.json | jq '.Name' -r))
 	docker exec ${CONTAINER_TEST_ID} bash -i -c "bun i"
 	docker exec ${CONTAINER_TEST_ID} bash -i -c "bun test ${TEST_ARG}"
+
+.PHONY: build_version_file
+build_version_file:
+	cat package.json | jq '.version | "export const ACTIOMAN_VERSION = " + (. | @json) + ";"' -r > src/actioman-version.ts


### PR DESCRIPTION
## Changes

This pull request updates the release workflow for the project. The changes include:

1. Added a new `build_version_file` target to the Makefile. This target reads the version from the `package.json` file and generates a TypeScript file `src/actioman-version.ts` that exports the version as a constant. This allows the version to be easily accessed throughout the codebase.

2. Added a new release workflow that is triggered on pushes to the `develop` branch. The workflow uses the existing `bun-release-package` workflow from the `jondotsoy/jondotsoy` repository to handle the release process.

3. Added a new `prepare` job that runs after the release job. This job checks if a release was created, and if not, it builds a new version file and commits the changes to the repository.

These changes will help streamline the release process for the project and ensure that the version information is consistently available throughout the codebase.