### PR TITLE
build: improve release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     needs:
       - release
     runs-on: ubuntu-latest
-    if: !needs.release.outputs.release_created
+    if: ${{ !needs.release.outputs.release_created == false }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Changes

This pull request improves the release workflow condition to correctly check if a release was already created. The previous condition was incorrect and would always evaluate to true, causing the workflow to run even when a release was already created.

The changes include:

- Modify the release workflow to correctly check if a release was already created.