### PR TITLE
feat: Improve release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     needs:
       - release
     runs-on: ubuntu-latest
-    if: ${{ !needs.release.outputs.release_created == false }}
+    if: ${{ !needs.release.outputs.release_created }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Changes

This pull request improves the release workflow condition to only run when a new release is not created. The changes ensure the workflow only executes when a new release is needed, improving the overall efficiency of the release process.

