### PR TITLE
build: Conditionally run release workflow based on PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     needs:
       - release
     runs-on: ubuntu-latest
-    if: ${{ !needs.release.outputs.prs_created }}
+    if: ${{ needs.release.outputs.prs_created }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Changes

This pull request conditionally runs the release workflow based on the creation of a pull request. The changes include:

- Modifying the release workflow to only run if the previous release workflow created pull requests. This ensures the release workflow only runs when there are changes to be released, reducing unnecessary workflow runs.