### PR TITLE
feat(cli): add context to main commands

### DIFF
--- a/src/cli/actioman.ts
+++ b/src/cli/actioman.ts
@@ -1,5 +1,18 @@
 #!/usr/bin/env node
 
+import { MessageTrace } from "../telemetry/message-trace.js";
+import { defaultTelemetryConfig } from "../telemetry/telemetry-config.js";
+import { Telemetry } from "../telemetry/telemetry.js";
 import { main } from "./cmds/main.js";
 
-await main(process.argv.slice(2));
+const telemetry = new Telemetry(defaultTelemetryConfig()).start();
+const pendingMessage = new MessageTrace(telemetry);
+
+pendingMessage.type = "command_execution";
+
+await main(process.argv.slice(2), {
+  telemetry,
+  pendingMessage,
+}).finally(() => {
+  pendingMessage.push();
+});

--- a/src/cli/cmds/add.ts
+++ b/src/cli/cmds/add.ts
@@ -9,8 +9,11 @@ import {
   type Rule,
 } from "@jondotsoy/flags";
 import { importRemoteActions } from "../../scripts/import-remote-actions.js";
+import type { CliContextDTO } from "../dto/cli-context.dto.js";
 
-export const add = async (args: string[]) => {
+export const add = async (args: string[], ctx: CliContextDTO) => {
+  ctx.pendingMessage.command = "add";
+
   type Options = {
     help: boolean;
     cwd: string;

--- a/src/cli/cmds/install.ts
+++ b/src/cli/cmds/install.ts
@@ -13,6 +13,7 @@ import { getCWD } from "../utils/get-cwd.js";
 import { ActionmanLockFile } from "../../actioman-lock-file/actioman-lock-file.js";
 import { importRemoteAction } from "../../scripts/import-remote-actions.js";
 import { ActionsDocument } from "../../exporter-actions/exporter-actions.js";
+import type { CliContextDTO } from "../dto/cli-context.dto.js";
 
 async function installHandler(cwdUrl: URL) {
   const actiomanLockFileLocation = getActiomanLockFileLocation(cwdUrl);
@@ -35,7 +36,9 @@ async function installHandler(cwdUrl: URL) {
   }
 }
 
-export const install = async (args: string[]) => {
+export const install = async (args: string[], ctx: CliContextDTO) => {
+  ctx.pendingMessage.command = "install";
+
   type Options = {
     cwd: string;
     help: boolean;

--- a/src/cli/cmds/main.ts
+++ b/src/cli/cmds/main.ts
@@ -11,8 +11,9 @@ import {
 import { serve } from "./serve.js";
 import { add } from "./add.js";
 import { install } from "./install.js";
+import type { CliContextDTO } from "../dto/cli-context.dto.js";
 
-export const main = async (args: string[]) => {
+export const main = async (args: string[], ctx: CliContextDTO) => {
   type Options = {
     help: boolean;
     serve: string[];
@@ -36,9 +37,9 @@ export const main = async (args: string[]) => {
   const options = flags(args, {}, rules);
 
   if (options.help) return console.log(makeHelpMessage("actioman", rules));
-  if (options.add) return await add(options.add);
-  if (options.serve) return await serve(options.serve);
-  if (options.install) return await install(options.install);
+  if (options.add) return await add(options.add, ctx);
+  if (options.serve) return await serve(options.serve, ctx);
+  if (options.install) return await install(options.install, ctx);
 
   return console.log(makeHelpMessage("actioman", rules));
 };

--- a/src/cli/cmds/serve.ts
+++ b/src/cli/cmds/serve.ts
@@ -12,7 +12,9 @@ import {
 import * as net from "net";
 import { makeServerScript } from "../../scripts/make-server-script.js";
 import { getCWD } from "../utils/get-cwd.js";
-import { spawnSync } from "child_process";
+import { spawn, spawnSync } from "child_process";
+import { ACTIOMAN_VERSION } from "../../actioman-version.js";
+import type { CliContextDTO } from "../dto/cli-context.dto.js";
 
 const nextPort = async () => {
   let porposalPort = 30320;
@@ -36,7 +38,9 @@ const nextPort = async () => {
   }
 };
 
-export const serve = async (args: string[]) => {
+export const serve = async (args: string[], ctx: CliContextDTO) => {
+  ctx.pendingMessage.command = "serve";
+
   type Options = {
     help: boolean;
     http2: boolean;
@@ -92,7 +96,9 @@ export const serve = async (args: string[]) => {
     http2,
   );
 
-  spawnSync(process.argv0, [new URL(bootstrapLocation).pathname], {
+  ctx.pendingMessage.push();
+
+  spawn(process.argv0, [new URL(bootstrapLocation).pathname], {
     cwd: cwd.pathname,
     env: {
       ...process.env,

--- a/src/cli/dto/cli-context.dto.ts
+++ b/src/cli/dto/cli-context.dto.ts
@@ -1,0 +1,7 @@
+import type { Telemetry } from "../../telemetry/telemetry";
+import type { MessageTrace } from "../../telemetry/message-trace";
+
+export type CliContextDTO = {
+  telemetry: Telemetry;
+  pendingMessage: MessageTrace;
+};


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## Changes

This pull request adds context to the main CLI commands (`add`, `serve`, and `install`) by introducing a `CliContextDTO` object. This context object contains a `Telemetry` instance and a `MessageTrace` instance, which are used to track and report command execution telemetry.

The main reasons for these changes are:

1. To enable better telemetry and reporting of CLI command execution.
2. To provide a centralized way to manage and pass context information to the various CLI commands.
3. To prepare the CLI for future extensibility and maintainability.

The most important changes are:

- Adding the `CliContextDTO` type and its properties to the CLI commands.
- Updating the `main`, `add`, `serve`, and `install` functions to accept the `CliContextDTO` object as a parameter.
- Updating the `serve` command to use the `spawn` function instead of `spawnSync` to allow for better telemetry tracking.
- Adding the `pendingMessage` property to the `CliContextDTO` object and updating the CLI commands to use it to track and report command execution.