### PR TITLE
docs: add commit message guidelines following Conventional Commits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@ Use the following format for your commit messages:
 ```
 
 ## Allowed types
+
 - feat: A new feature
 - fix: A bug fix
 - docs: Documentation changes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,49 @@
+# Reglas para los Commits
+
+Este repositorio sigue las reglas de [Conventional Commits](https://www.conventionalcommits.org/es/v1.0.0/).
+
+Utiliza el siguiente formato para tus mensajes de commit:
+
+```
+<tipo>[ámbito opcional]: <descripción>
+
+[cuerpo opcional]
+
+[nota(s) al pie opcional(es)]
+```
+
+## Tipos permitidos
+- feat: Una nueva característica
+- fix: Corrección de un error
+- docs: Cambios en la documentación
+- style: Cambios que no afectan el significado del código (espacios en blanco, formato, puntos y comas, etc.)
+- refactor: Cambios en el código que no corrigen errores ni agregan funcionalidades
+- perf: Cambios que mejoran el rendimiento
+- test: Agregar o corregir pruebas
+- build: Cambios que afectan el sistema de construcción o dependencias externas
+- ci: Cambios en los archivos y scripts de CI
+- chore: Otros cambios que no modifican src ni archivos de prueba
+- revert: Revertir un commit anterior
+
+## Ámbito
+
+El ámbito debe corresponder al nombre de la carpeta modificada dentro de `./src/<ámbito>`. Por ejemplo, si modificas archivos en `./src/cli/`, el mensaje de commit debe ser:
+
+```
+<tipo>(cli): <descripción>
+```
+
+## Ejemplo
+
+```
+feat(cli): agregar opción --verbose al comando run
+
+Permite a los usuarios ver más detalles durante la ejecución.
+
+BREAKING CHANGE: la opción --debug ha sido reemplazada por --verbose
+```
+
+- Usa el modo imperativo en la descripción ("agregar" en vez de "agregado" o "agrega").
+- Limita la descripción a 72 caracteres.
+- Si el commit introduce un cambio importante, añade una nota al pie con `BREAKING CHANGE:`.
+- Si el commit cierra un issue, referencia el número en el cuerpo o nota al pie.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,49 +1,49 @@
-# Reglas para los Commits
+# Commit Rules
 
-Este repositorio sigue las reglas de [Conventional Commits](https://www.conventionalcommits.org/es/v1.0.0/).
+This repository follows the rules of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
-Utiliza el siguiente formato para tus mensajes de commit:
-
-```
-<tipo>[ámbito opcional]: <descripción>
-
-[cuerpo opcional]
-
-[nota(s) al pie opcional(es)]
-```
-
-## Tipos permitidos
-- feat: Una nueva característica
-- fix: Corrección de un error
-- docs: Cambios en la documentación
-- style: Cambios que no afectan el significado del código (espacios en blanco, formato, puntos y comas, etc.)
-- refactor: Cambios en el código que no corrigen errores ni agregan funcionalidades
-- perf: Cambios que mejoran el rendimiento
-- test: Agregar o corregir pruebas
-- build: Cambios que afectan el sistema de construcción o dependencias externas
-- ci: Cambios en los archivos y scripts de CI
-- chore: Otros cambios que no modifican src ni archivos de prueba
-- revert: Revertir un commit anterior
-
-## Ámbito
-
-El ámbito debe corresponder al nombre de la carpeta modificada dentro de `./src/<ámbito>`. Por ejemplo, si modificas archivos en `./src/cli/`, el mensaje de commit debe ser:
+Use the following format for your commit messages:
 
 ```
-<tipo>(cli): <descripción>
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footnote(s)]
 ```
 
-## Ejemplo
+## Allowed types
+- feat: A new feature
+- fix: A bug fix
+- docs: Documentation changes
+- style: Changes that do not affect the meaning of the code (whitespace, formatting, missing semicolons, etc.)
+- refactor: Code changes that neither fix a bug nor add a feature
+- perf: Changes that improve performance
+- test: Adding or correcting tests
+- build: Changes that affect the build system or external dependencies
+- ci: Changes to CI configuration files and scripts
+- chore: Other changes that do not modify src or test files
+- revert: Revert a previous commit
+
+## Scope
+
+The scope must match the name of the folder modified inside `./src/<scope>`. For example, if you modify files in `./src/cli/`, the commit message should be:
 
 ```
-feat(cli): agregar opción --verbose al comando run
-
-Permite a los usuarios ver más detalles durante la ejecución.
-
-BREAKING CHANGE: la opción --debug ha sido reemplazada por --verbose
+<type>(cli): <description>
 ```
 
-- Usa el modo imperativo en la descripción ("agregar" en vez de "agregado" o "agrega").
-- Limita la descripción a 72 caracteres.
-- Si el commit introduce un cambio importante, añade una nota al pie con `BREAKING CHANGE:`.
-- Si el commit cierra un issue, referencia el número en el cuerpo o nota al pie.
+## Example
+
+```
+feat(cli): add --verbose option to run command
+
+Allows users to see more details during execution.
+
+BREAKING CHANGE: the --debug option has been replaced by --verbose
+```
+
+- Use the imperative mood in the description ("add" instead of "added" or "adds").
+- Limit the description to 72 characters.
+- If the commit introduces a breaking change, add a footnote with `BREAKING CHANGE:`.
+- If the commit closes an issue, reference the number in the body or footnote.


### PR DESCRIPTION
This pull request introduces a new `.github/copilot-instructions.md` file to establish commit message guidelines for the repository. The guidelines enforce the use of the Conventional Commits specification to standardize commit messages.

### Commit Message Guidelines:

* Introduced a new `.github/copilot-instructions.md` file detailing the adoption of the Conventional Commits format for commit messages. This includes:
  - A structured format with `<type>[optional scope]: <description>` and optional body/footnotes. 
  - A list of allowed commit types (e.g., `feat`, `fix`, `docs`, etc.).
  - Scope naming rules tied to folder names within `./src/<scope>`.
  - Examples and best practices, such as using the imperative mood and referencing breaking changes or issues.