### PR TITLE
docs: update README and add API reference for advanced usage

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -41,14 +41,14 @@ Para empezar a usar actioman, sigue estos sencillos pasos:
    ```
    Route GET /__actions
    Route POST /__actions/hello
-   Listening on http://localhost:30320/
+   Listening on http://localhost:30321/
    ```
 
    Este mensaje indica:
 
    - `Route GET /__actions`: Se ha creado una ruta GET en `/__actions`. Esta ruta expone los contratos de todos los servicios definidos en `actions.js` en formato JSON. Puedes usarla para inspeccionar la estructura de tus servicios.
    - `Route POST /__actions/hello`: Se ha creado una ruta POST en `/__actions/hello`. Esta ruta corresponde a la función `hello` que definiste en `actions.js`. Para invocar este servicio, deberás hacer una petición POST a esta URL.
-   - `Listening on http://localhost:30320/`: El servidor actioman está corriendo y escuchando peticiones en la URL `http://localhost:30320/`. El puerto `30320` puede variar.
+   - `Listening on http://localhost:30321/`: El servidor actioman está corriendo y escuchando peticiones en la URL `http://localhost:30321/`. El puerto por defecto es `30321`, pero puede ser modificado usando el argumento `--port` al iniciar el servidor.
 
 ## Agregando servicios Actioman a tu proyecto
 

--- a/docs/es/actions.md
+++ b/docs/es/actions.md
@@ -1,4 +1,4 @@
-## 📜 Archivo de Acciones: Definiendo tus Servicios Actioman
+## Archivo de Acciones: Definiendo tus Servicios Actioman
 
 El archivo de acciones es el corazón de tu servicio Actioman. Por convención, a menudo se nombra `actions.js`, pero **puedes elegir el nombre de archivo que prefieras**. Este archivo Javascript contiene todas las **acciones** o **servicios** que quieres exponer a través de tu API. Actioman escanea este archivo y automáticamente convierte cada función exportada en un endpoint web accesible.
 

--- a/docs/es/api-reference.md
+++ b/docs/es/api-reference.md
@@ -1,0 +1,52 @@
+# Referencia de API: Uso avanzado de Actioman desde código
+
+Esta sección describe cómo crear y controlar un servidor Actioman directamente desde código, permitiendo un control total sobre el ciclo de vida, la integración con middlewares personalizados y la extensión del comportamiento del servidor.
+
+## Crear un servidor Actioman manualmente
+
+Puedes iniciar un servidor Actioman desde tu propio código, lo que te permite:
+- Iniciar y detener el servidor bajo demanda.
+- Integrar lógica personalizada antes o después de cada acción.
+- Integrar Actioman en aplicaciones más grandes o flujos personalizados.
+
+### Ejemplo básico
+
+```ts
+import { HTTPLister } from "actioman/http-router";
+import * as myModule from "./my-functions.ts";
+
+const httpListener = await HTTPLister.fromModule(myModule);
+// Aquí puedes agregar lógica personalizada antes de iniciar el servidor
+await httpListener.listen();
+// También puedes controlar el cierre del servidor o manejar eventos personalizados
+```
+
+Con este enfoque, tienes acceso directo al ciclo de vida del servidor y puedes extender su comportamiento según tus necesidades.
+
+## Consumir los servicios desde cualquier cliente HTTP
+
+Una vez levantado el servidor, puedes consumir los servicios usando cualquier herramienta o lenguaje que soporte HTTP, como curl, Postman, fetch, etc.
+
+```bash
+# Descubrir los servicios disponibles
+curl http://localhost:30320/__actions
+
+# Invocar una función (por ejemplo, "sumar")
+curl -X POST http://localhost:30320/__actions/sumar \
+  -H "Content-Type: application/json" \
+  -d '{"a":5,"b":3}'
+```
+
+O desde Javascript usando fetch:
+
+```js
+const res = await fetch("http://localhost:30320/__actions/sumar", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ a: 5, b: 3 })
+});
+const result = await res.json();
+console.log(result); // 8
+```
+
+Así puedes integrar Actioman en cualquier ecosistema, con control total sobre el servidor y sin depender del cliente oficial.


### PR DESCRIPTION
This pull request updates the Spanish documentation for Actioman to reflect changes in default server behavior, enhance clarity, and introduce advanced usage examples. The most important changes include updating the default server port, improving section titles for consistency, and adding a new section on advanced API usage.

### Updates to default server behavior:
* [`docs/es/README.md`](diffhunk://#diff-b72ce5341b20c6c47a634399985a91fa66e976cd1a29f87ecd193e2d93506b2dL44-R51): Updated the default server port from `30320` to `30321` and clarified that the port can be customized using the `--port` argument.

### Documentation improvements:
* [`docs/es/actions.md`](diffhunk://#diff-c7bf1f767b15b60aedd1ff00ca9193d09b6cd5cb8575acbae28cb15eab62958cL1-R1): Simplified the section title by removing the emoji for a cleaner and more professional appearance.

### Advanced usage examples:
* [`docs/es/api-reference.md`](diffhunk://#diff-e79751227e6aa386f40dd018dc9d42ef1475badef9c86f3d64f9ae1b0824e99eR1-R52): Added a new section detailing how to create and control an Actioman server programmatically, with examples for manual server lifecycle management and consuming services via HTTP.