### PR TITLE
fix: improve code formatting and consistency in API reference and ser…

### DIFF
--- a/docs/es/api-reference.md
+++ b/docs/es/api-reference.md
@@ -5,6 +5,7 @@ Esta sección describe cómo crear y controlar un servidor Actioman directamente
 ## Crear un servidor Actioman manualmente
 
 Puedes iniciar un servidor Actioman desde tu propio código, lo que te permite:
+
 - Iniciar y detener el servidor bajo demanda.
 - Integrar lógica personalizada antes o después de cada acción.
 - Integrar Actioman en aplicaciones más grandes o flujos personalizados.
@@ -43,7 +44,7 @@ O desde Javascript usando fetch:
 const res = await fetch("http://localhost:30320/__actions/sumar", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ a: 5, b: 3 })
+  body: JSON.stringify({ a: 5, b: 3 }),
 });
 const result = await res.json();
 console.log(result); // 8

--- a/src/cli/cmds/serve.ts
+++ b/src/cli/cmds/serve.ts
@@ -14,7 +14,6 @@ import { getCWD } from "../utils/get-cwd.js";
 import { spawn } from "child_process";
 import type { CliContextDTO } from "../dto/cli-context.dto.js";
 
-
 export const serve = async (args: string[], ctx: CliContextDTO) => {
   ctx.pendingMessage.command = "serve";
 
@@ -31,10 +30,12 @@ export const serve = async (args: string[], ctx: CliContextDTO) => {
       description: "Set the current working directory for the server process",
     }),
     rule(flag("-p", "--port"), isNumberAt("port"), {
-      description: "Specify the port for the server to listen on (default: 30321)",
+      description:
+        "Specify the port for the server to listen on (default: 30321)",
     }),
     rule(flag("-h", "--host"), isStringAt("host"), {
-      description: "Specify the host address for the server (default: localhost)",
+      description:
+        "Specify the host address for the server (default: localhost)",
     }),
     rule(flag("--http2"), isBooleanAt("http2"), {
       description: "Enable HTTP2 support (experimental feature)",

--- a/src/http-router/http2-listener.ts
+++ b/src/http-router/http2-listener.ts
@@ -97,8 +97,7 @@ export class HTTP2Lister {
       console.log(message);
     };
 
-    const portToListen =
-      port ?? this.configs?.server?.port ?? 30321;
+    const portToListen = port ?? this.configs?.server?.port ?? 30321;
     const hostnameToListen = hostname ?? this.configs?.server?.host ?? "::";
 
     const url = await new Promise<URL>((resolve) => {


### PR DESCRIPTION
This pull request includes documentation updates and minor code adjustments to improve readability and consistency. The most important changes include refining Spanish documentation, fixing formatting in TypeScript code, and ensuring consistent default values in the HTTP2 listener.

### Documentation Updates:

* [`docs/es/api-reference.md`](diffhunk://#diff-e79751227e6aa386f40dd018dc9d42ef1475badef9c86f3d64f9ae1b0824e99eR8): Added a missing blank line in the "Crear un servidor Actioman manualmente" section for better formatting.
* [`docs/es/api-reference.md`](diffhunk://#diff-e79751227e6aa386f40dd018dc9d42ef1475badef9c86f3d64f9ae1b0824e99eL46-R47): Corrected a minor syntax issue by adding a trailing comma in the `fetch` example for consistency.

### Code Formatting and Consistency:

* [`src/cli/cmds/serve.ts`](diffhunk://#diff-0963fa9902a3ba1aa2e4128d8ea9bd361f17748d89afc806063cbf6a832e3799L34-R38): Adjusted line breaks in descriptions for `--port` and `--host` flags to improve code readability.
* [`src/cli/cmds/serve.ts`](diffhunk://#diff-0963fa9902a3ba1aa2e4128d8ea9bd361f17748d89afc806063cbf6a832e3799L17): Removed an unnecessary blank line to maintain consistent formatting.
* [`src/http-router/http2-listener.ts`](diffhunk://#diff-02ca76a71ecb6ba332919c034602d7ba5242d5984309134c66b7435a6897d739L100-R100): Simplified the assignment of `portToListen` to ensure consistent formatting with no functional changes.