### PR TITLE
tests: update container setup to initialize Actioman CLI and run npm pack

### DIFF
--- a/tests/integration/container/src/constants/bun_source_container_path.ts
+++ b/tests/integration/container/src/constants/bun_source_container_path.ts
@@ -2,4 +2,6 @@
  * Static variable representing the Bun cache directory path inside the container.
  * @type {URL}
  */
-export const bunSourceContainerPath = new URL("file:///root/.bun/");
+export const bunSourceContainerPath = new URL(
+  "file:///root/.bun/install/cache",
+);

--- a/tests/integration/container/src/constants/image_name.ts
+++ b/tests/integration/container/src/constants/image_name.ts
@@ -2,4 +2,4 @@
  * Static variable for the Docker image name used in integration tests.
  * @type {string}
  */
-export const IMAGE_NAME = "oven/bun:latest";
+export const IMAGE_NAME = "jondotsoy/js-container-tools:latest";

--- a/tests/integration/container/src/constants/project_source_paths.ts
+++ b/tests/integration/container/src/constants/project_source_paths.ts
@@ -1,4 +1,10 @@
 /**
  * List of project source files and configuration to mount in the container.
  */
-export const PROJECT_SOURCE_PATHS = ["./src", "./package.json", "./bun.lock"];
+export const PROJECT_SOURCE_PATHS = [
+  "./src",
+  "./package.json",
+  "./bun.lock",
+  "./tsconfig.json",
+  "./tsconfig.esm.json",
+];

--- a/tests/integration/container/src/initialize_actioman_cli.ts
+++ b/tests/integration/container/src/initialize_actioman_cli.ts
@@ -4,13 +4,42 @@ import { docker } from "./docker";
 import { getStoredContainerPID } from "./get_stored_container_pid";
 import type { initializeCliActiomanOptions } from "./initialize_cli_actioman_options";
 
+type ShellOptions = {
+  workspace?: string;
+};
+
 /**
- * Initializes CLI commands for interacting with the Actioman process inside a Docker container.
+ * Initializes CLI helpers for interacting with the Actioman process inside a Docker container.
  *
- * Provides helpers for running shell, entrypoint, exec, killExec, and actioman commands in the container.
+ * Returns an object with utilities to run commands in the container:
+ * - `pid`: The container process ID.
+ * - `shell`: Run a command in the container.
+ * - `shellWithOptions`: Run a command with options (e.g., workspace).
+ * - `entrypoint`: Run a script via the container's entrypoint.
+ * - `exec`: Run an exec command via entrypoint (for Actioman CLI commands).
+ * - `killExec`: Run a kill-exec command via entrypoint (to terminate processes).
+ * - `actioman`: Run the Actioman CLI inside the container (using Bun runner).
+ * - `clearAppSource`: Clear the app source in the container (removes app code).
+ * - `actiomanSourceContainerShell`: Run a command in the Actioman source workspace inside the container.
  *
- * @param {initializeCliActiomanOptions} [options] - Optional initialization options.
- * @returns {Promise<{ pid: string, shell: Function, actioman: Function, entrypoint: Function, exec: Function, killExec: Function, clearAppSource: Function }>} CLI helpers and container PID.
+ * @param {initializeCliActiomanOptions} [options] - Optional initialization options for the CLI helpers.
+ * @returns {Promise<{
+ *   pid: string,
+ *   shell: (...args: string[]) => ReturnType<typeof docker>,
+ *   shellWithOptions: (options: ShellOptions, ...args: string[]) => ReturnType<typeof docker>,
+ *   actioman: (...args: string[]) => ReturnType<typeof docker>,
+ *   entrypoint: (...args: string[]) => ReturnType<typeof docker>,
+ *   exec: (...args: string[]) => ReturnType<typeof docker>,
+ *   killExec: (...args: string[]) => ReturnType<typeof docker>,
+ *   clearAppSource: (...args: string[]) => ReturnType<typeof docker>,
+ *   actiomanSourceContainerShell: (...args: string[]) => ReturnType<typeof docker>,
+ * }>} CLI helpers and container PID.
+ *
+ * @example
+ * const cli = await initializeActiomanCli();
+ * await cli.actioman("--help");
+ * await cli.shell("ls", "/");
+ * await cli.clearAppSource();
  */
 export const initializeActiomanCli = async (
   options?: initializeCliActiomanOptions,
@@ -21,20 +50,73 @@ export const initializeActiomanCli = async (
     throw new Error("No container found to execute command.");
   }
 
-  const shell = (...args: string[]) => docker("exec", pid, ...args);
+  /**
+   * Runs a command in the Docker container with additional options.
+   * @param {ShellOptions} options - Options such as workspace.
+   * @param {...string} args - Command and arguments to execute.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
+  const shellWithOptions = (options: ShellOptions, ...args: string[]) => {
+    const dockerArgs: string[] = [];
 
+    if (options.workspace) {
+      dockerArgs.push("-w", options.workspace);
+    }
+
+    return docker("exec", ...dockerArgs, pid, ...args);
+  };
+
+  /**
+   * Runs a command in the Docker container.
+   * @param {...string} args - Command and arguments to execute.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
+  const shell = (...args: string[]) => shellWithOptions({}, ...args);
+
+  /**
+   * Runs a script using the container's entrypoint.
+   * @param {...string} args - Arguments for the entrypoint.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
   const entrypoint = (...args: string[]) =>
-    docker(
-      "exec",
-      pid,
+    shell(
       "sh",
       `${new URL("entrypoint.sh", containerScriptsContainerPath).pathname}`,
       ...args,
     );
 
+  /**
+   * Runs a command in the Actioman source workspace inside the container.
+   * @param {...string} args - Command and arguments to execute.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
+  const actiomanSourceContainerShell = (...args: string[]) =>
+    shellWithOptions(
+      {
+        workspace: actiomanSourceContainerPath.pathname,
+      },
+      ...args,
+    );
+
+  /**
+   * Runs the 'exec' command using the entrypoint.
+   * @param {...string} args - Arguments for 'exec'.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
   const exec = (...args: string[]) => entrypoint("exec", ...args);
+
+  /**
+   * Runs the 'kill-exec' command using the entrypoint.
+   * @param {...string} args - Arguments for 'kill-exec'.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
   const killExec = (...args: string[]) => entrypoint("kill-exec", ...args);
 
+  /**
+   * Runs the Actioman CLI inside the container.
+   * @param {...string} args - Arguments for the Actioman CLI.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
   const actioman = (...args: string[]) =>
     exec(
       "bun",
@@ -43,16 +125,23 @@ export const initializeActiomanCli = async (
       ...args,
     );
 
+  /**
+   * Clears the app source code inside the container.
+   * @param {...string} args - Arguments to clear the source code.
+   * @returns {ReturnType<typeof docker>} Result of the execution.
+   */
   const clearAppSource = (...args: string[]) =>
     entrypoint("clear-app-source", ...args);
 
   return {
     pid,
     shell,
+    shellWithOptions,
     actioman,
     entrypoint,
     exec,
     killExec,
     clearAppSource,
+    actiomanSourceContainerShell,
   };
 };

--- a/tests/integration/container/src/setup_container.ts
+++ b/tests/integration/container/src/setup_container.ts
@@ -18,6 +18,8 @@ export const setupContainer = async () => {
   await fs.mkdir(scriptsLocalPath, { recursive: true });
 
   await bootstrapContainer();
+  const { actiomanSourceContainerShell } = await initializeActiomanCli({});
+  await actiomanSourceContainerShell("npm", "pack").verbose().exited;
 };
 
 export const cleanupContainer = async () => {


### PR DESCRIPTION
This pull request introduces updates to integration test constants, enhances the `initializeActiomanCli` utility with additional functionality, and modifies the container setup process to include new commands. The changes improve flexibility and functionality for managing Docker containers and integration tests.

### Updates to integration test constants:

* Updated the `bunSourceContainerPath` to reflect a new directory structure (`file:///root/.bun/install/cache`).
* Changed the Docker image name in `IMAGE_NAME` from `oven/bun:latest` to `jondotsoy/js-container-tools:latest`.
* Added additional source paths (`tsconfig.json` and `tsconfig.esm.json`) to `PROJECT_SOURCE_PATHS` for mounting in the container.

### Enhancements to `initializeActiomanCli`:

* Introduced a `ShellOptions` type and a new `shellWithOptions` method to allow running commands with additional options like workspace configuration. [[1]](diffhunk://#diff-e787018763022c397f007ed124b358d13658951f4a2692b1a92946281e6377a2R7-R42) [[2]](diffhunk://#diff-e787018763022c397f007ed124b358d13658951f4a2692b1a92946281e6377a2L24-R119)
* Added new methods such as `actiomanSourceContainerShell` for running commands in the Actioman source workspace and `clearAppSource` for clearing the app source code in the container. [[1]](diffhunk://#diff-e787018763022c397f007ed124b358d13658951f4a2692b1a92946281e6377a2L24-R119) [[2]](diffhunk://#diff-e787018763022c397f007ed124b358d13658951f4a2692b1a92946281e6377a2R128-R145)

### Changes to container setup:

* Updated the `setupContainer` function to use the new `actiomanSourceContainerShell` method to execute `npm pack` in the Actioman source workspace.