### PR TITLE
feat(cli): add command `actioman version`

### DIFF
--- a/src/cli/cmds/main.ts
+++ b/src/cli/cmds/main.ts
@@ -11,6 +11,7 @@ import {
 import { serve } from "./serve.js";
 import { add } from "./add.js";
 import { install } from "./install.js";
+import { version } from "./version.js";
 import type { CliContextDTO } from "../dto/cli-context.dto.js";
 
 export const main = async (args: string[], ctx: CliContextDTO) => {
@@ -19,6 +20,7 @@ export const main = async (args: string[], ctx: CliContextDTO) => {
     serve: string[];
     install: string[];
     add: string[];
+    version: string[];
   };
   const rules: Rule<Options>[] = [
     rule(command("serve"), restArgumentsAt("serve"), {
@@ -30,6 +32,9 @@ export const main = async (args: string[], ctx: CliContextDTO) => {
     rule(command("install"), restArgumentsAt("install"), {
       description: "Install and prepare remote dependencies for use",
     }),
+    rule(command("version"), restArgumentsAt("version"), {
+      description: "Display the current version of the Actioman CLI",
+    }),
     rule(flag("-h", "--help"), isBooleanAt("help"), {
       description: "Display help information for available commands",
     }),
@@ -40,6 +45,7 @@ export const main = async (args: string[], ctx: CliContextDTO) => {
   if (options.add) return await add(options.add, ctx);
   if (options.serve) return await serve(options.serve, ctx);
   if (options.install) return await install(options.install, ctx);
+  if (options.version) return await version(options.version, ctx);
 
   return console.log(makeHelpMessage("actioman", rules));
 };

--- a/src/cli/cmds/template.ts
+++ b/src/cli/cmds/template.ts
@@ -6,8 +6,9 @@ import {
   rule,
   type Rule,
 } from "@jondotsoy/flags";
+import type { CliContextDTO } from "../dto/cli-context.dto";
 
-export const template = async (args: string[]) => {
+export const template = async (args: string[], ctx: CliContextDTO) => {
   type Options = { help: boolean };
   const rules: Rule<Options>[] = [
     rule(flag("-h", "--help"), isBooleanAt("help"), {

--- a/src/cli/cmds/version.ts
+++ b/src/cli/cmds/version.ts
@@ -1,0 +1,41 @@
+import {
+  flag,
+  flags,
+  isBooleanAt,
+  makeHelpMessage,
+  rule,
+  type Rule,
+} from "@jondotsoy/flags";
+import type { CliContextDTO } from "../dto/cli-context.dto.js";
+import { ACTIOMAN_VERSION } from "../../actioman-version.js";
+
+export const version = async (args: string[], ctx: CliContextDTO) => {
+  type Options = { help: boolean; json: boolean; zero: boolean };
+  const rules: Rule<Options>[] = [
+    rule(flag("-j", "--json"), isBooleanAt("json"), {
+      description: "Output in JSON format",
+    }),
+    rule(flag("-z"), isBooleanAt("zero"), {
+      description: "End output with a NUL (\0) character instead of a newline.",
+    }),
+    rule(flag("-h", "--help"), isBooleanAt("help"), {
+      description: "Show help information for the version command.",
+    }),
+  ];
+  const options = flags(args, {}, rules);
+  const outputJson = options.json ?? false;
+  const outputZero = options.zero ?? false;
+
+  if (outputJson) {
+    const output = JSON.stringify({ version: ACTIOMAN_VERSION });
+    process.stdout.write(output + (outputZero ? "\0" : "\n"));
+    return;
+  }
+
+  const help = () => console.log(makeHelpMessage("actioman version", rules));
+
+  if (options.help) return help();
+
+  const versionOutput = `Actioman version: ${ACTIOMAN_VERSION}`;
+  process.stdout.write(versionOutput + (outputZero ? "\0" : "\n"));
+};

--- a/tests/integration/__snapshots__/client.spec.ts.snap
+++ b/tests/integration/__snapshots__/client.spec.ts.snap
@@ -1,0 +1,12 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actioman version command should display help information 1`] = `
+"Usage: actioman version                                                         
+
+flag:
+   -j, --json   Output in JSON format                                           
+   -z           End output with a NUL (\x00) character instead of a newline.       
+   -h, --help   Show help information for the version command.                  
+
+"
+`;

--- a/tests/integration/client.spec.ts
+++ b/tests/integration/client.spec.ts
@@ -153,6 +153,7 @@ describe("actioman version command", () => {
     const { stdoutText } = await actioman("version", "--help").exited;
 
     expect(stdoutText).toContain("Usage:");
+    expect(stdoutText).toMatchSnapshot();
   });
 
   // $ actioman version -h

--- a/tests/integration/client.spec.ts
+++ b/tests/integration/client.spec.ts
@@ -15,6 +15,7 @@ describe("actioman serve command", () => {
     await cleanupContainer();
   });
 
+  // $ actioman serve app.ts
   it("should execute the serve command successfully", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -29,6 +30,7 @@ describe("actioman serve command", () => {
     expect(stdoutJson.statusCode).toBe(200);
   });
 
+  // $ actioman serve app.ts --port 30333
   it("should execute the serve command with --port option", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -45,6 +47,7 @@ describe("actioman serve command", () => {
     expect(stdoutJson.statusCode).toBe(200);
   });
 
+  // $ actioman serve app.ts --help
   it("should display help information", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -55,13 +58,14 @@ describe("actioman serve command", () => {
     expect(stdoutText).toContain("Usage:");
   });
 
+  // $ actioman serve app.ts
   it("should execute the serve command and log hello action", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
     await prepareScript("test_4", "app.ts");
     await prepareScript("test_4", "fetch.ts");
 
-    const childProcess = await actioman("serve", "app.ts").verbose();
+    const childProcess = await actioman("serve", "app.ts");
 
     let stdoutPartial: string = "";
     childProcess.stdoutSubscriber.subscribe((line) => {
@@ -77,6 +81,7 @@ describe("actioman serve command", () => {
     expect(stdoutJson.text).toBe(JSON.stringify("Hello from app.ts"));
   });
 
+  // $ actioman serve app.ts
   it("should execute the serve command with actioman.config.ts", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -89,6 +94,7 @@ describe("actioman serve command", () => {
     await childProcess.waitForLog("Server running at");
   });
 
+  // $ actioman serve app.ts
   it("should load configuration from .actioman.config.ts file", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -101,6 +107,7 @@ describe("actioman serve command", () => {
     await childProcess.waitForLog("Server running at");
   });
 
+  // $ actioman serve app.ts
   it("should load configuration from .actioman.config.js file", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -113,6 +120,7 @@ describe("actioman serve command", () => {
     await childProcess.waitForLog("Server running at");
   });
 
+  // $ actioman serve app.ts
   it("should load configuration from actioman.config.js file", async () => {
     const { shell, actioman } = await initializeActiomanCli();
 
@@ -123,5 +131,66 @@ describe("actioman serve command", () => {
 
     await childProcess.waitForLog("calling actioman.config.js");
     await childProcess.waitForLog("Server running at");
+  });
+});
+
+describe("actioman version command", () => {
+  afterEach(async () => {
+    await cleanupContainer();
+  });
+
+  // $ actioman version
+  it("should display the current version", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version").exited;
+
+    expect(stdoutText).toContain("Actioman version:");
+  });
+
+  // $ actioman version --help
+  it("should display help information", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version", "--help").exited;
+
+    expect(stdoutText).toContain("Usage:");
+  });
+
+  // $ actioman version -h
+  it("should display help information with short flag", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version", "-h").exited;
+
+    expect(stdoutText).toContain("Usage:");
+  });
+
+  // $ actioman version -j
+  it("should display the version in JSON format", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version", "-j").exited;
+
+    expect(stdoutText).toContain(`"version":`);
+  });
+
+  // $ actioman version --json
+  it("should display the version in JSON format with --json flag", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version", "--json").exited;
+    expect(stdoutText).toContain('"version":');
+  });
+
+  // $ actioman version -j -z
+  it("should display the version in JSON format ending with NUL when using -j -z", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version", "-j", "-z").exited;
+    expect(stdoutText.endsWith("\0")).toBe(true);
+    expect(stdoutText).toContain('"version":');
+  });
+
+  // $ actioman version -z
+  it("should display the version ending with NUL when using -z", async () => {
+    const { actioman } = await initializeActiomanCli();
+    const { stdoutText } = await actioman("version", "-z").exited;
+    expect(stdoutText.endsWith("\0")).toBe(true);
+    expect(stdoutText).toContain("Actioman version:");
   });
 });

--- a/tests/integration/container/entrypoint.sh
+++ b/tests/integration/container/entrypoint.sh
@@ -225,7 +225,7 @@ exec_command() {
   "$@" &
   PID=$!
   echo $PID >> "$COMMAND_PIDS_FILE"
-  echo "Command '$*' is running with PID $PID."
+  # echo "Command '$*' is running with PID $PID."
   # Wait for the command to finish
   wait $PID
 }


### PR DESCRIPTION
This pull request introduces a new `version` command to the Actioman CLI, enabling users to display the current version of the CLI with various output options. It also includes updates to the `serve` command test cases and minor adjustments to the integration testing setup.

### New `version` command:
* Added a `version` command to the CLI, allowing users to display the current version of Actioman. The command supports flags for JSON output (`-j`, `--json`), ending output with a NUL character (`-z`), and displaying help information (`-h`, `--help`). (`src/cli/cmds/main.ts` [[1]](diffhunk://#diff-32c4971adced02456299d624d143460f37f2edcea6b1639ebb1e3fced0f4d915R14) [[2]](diffhunk://#diff-32c4971adced02456299d624d143460f37f2edcea6b1639ebb1e3fced0f4d915R23) [[3]](diffhunk://#diff-32c4971adced02456299d624d143460f37f2edcea6b1639ebb1e3fced0f4d915R35-R37) [[4]](diffhunk://#diff-32c4971adced02456299d624d143460f37f2edcea6b1639ebb1e3fced0f4d915R48)], `src/cli/cmds/version.ts` [[5]](diffhunk://#diff-0b1c8d5caf1fc1111ba05922391290f4e527d14e164e4a973555aae78e7f7c0fR1-R41)])

### Updates to test cases:
* Added integration tests for the `version` command, covering scenarios such as displaying the version, showing help information, outputting JSON, and using the `-z` flag. (`tests/integration/client.spec.ts` [[tests/integration/client.spec.tsR136-R197](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R136-R197)])
* Updated snapshot for the `version` command help output. (`tests/integration/__snapshots__/client.spec.ts.snap` [[tests/integration/__snapshots__/client.spec.ts.snapR1-R12](diffhunk://#diff-d50728a932f819910d1856927695bebb2ebfa81f21e3c0b60b2e49db08d80b34R1-R12)])
* Enhanced comments in `serve` command test cases for clarity. (`tests/integration/client.spec.ts` [[1]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R18) [[2]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R33) [[3]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R50) [[4]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R61-R68) [[5]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R84) [[6]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R97) [[7]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R110) [[8]](diffhunk://#diff-8db5d5e15fd08a662e70fe95b0afb1eb493225a764f2ae07e879a51796e0c660R123)])

### Minor improvements:
* Updated `template.ts` to include `CliContextDTO` as a parameter for consistency across CLI commands. (`src/cli/cmds/template.ts` [[src/cli/cmds/template.tsR9-R11](diffhunk://#diff-150aa3e8caa33cbffd1a888a48ff11242b4f534ab5c1b5a54cc79a7c290de547R9-R11)])
* Commented out a debug log in the `exec_command` function within the integration test container entrypoint script. (`tests/integration/container/entrypoint.sh` [[tests/integration/container/entrypoint.shL228-R228](diffhunk://#diff-a9ee31f084bf58bc7ff2f48181899311e3cd112e6b016e9a04f428a4b7a604c3L228-R228)])