### PR TITLE
fix(cli): implement synchronous command execution with runSync utility

### DIFF
--- a/src/cli/cmds/serve.ts
+++ b/src/cli/cmds/serve.ts
@@ -92,6 +92,8 @@ export const serve = async (args: string[], ctx: CliContextDTO) => {
     return new Error(`Process exited with code ${code}`);
   };
 
+  if (p.error) throw p.error;
+
   const error = exitCodeToError(p.status);
 
   if (error) throw error;

--- a/src/cli/cmds/serve.ts
+++ b/src/cli/cmds/serve.ts
@@ -11,8 +11,8 @@ import {
 } from "@jondotsoy/flags";
 import { makeServerScript } from "../../scripts/make-server-script.js";
 import { getCWD } from "../utils/get-cwd.js";
-import { spawn } from "child_process";
 import type { CliContextDTO } from "../dto/cli-context.dto.js";
+import { runSync } from "../utils/run-sync.js";
 
 export const serve = async (args: string[], ctx: CliContextDTO) => {
   ctx.pendingMessage.command = "serve";
@@ -76,7 +76,7 @@ export const serve = async (args: string[], ctx: CliContextDTO) => {
 
   ctx.pendingMessage.push();
 
-  spawn(process.argv0, [new URL(bootstrapLocation).pathname], {
+  const p = runSync(process.argv0, [new URL(bootstrapLocation).pathname], {
     cwd: cwd.pathname,
     env: {
       ...process.env,
@@ -85,4 +85,14 @@ export const serve = async (args: string[], ctx: CliContextDTO) => {
     },
     stdio: "inherit",
   });
+
+  const exitCodeToError = (code: number | null) => {
+    if (code === null) return new Error("Process terminated by signal");
+    if (code === 0) return null;
+    return new Error(`Process exited with code ${code}`);
+  };
+
+  const error = exitCodeToError(p.status);
+
+  if (error) throw error;
 };

--- a/src/cli/utils/run-sync.ts
+++ b/src/cli/utils/run-sync.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from "child_process";
+import type { SpawnSyncOptions, SpawnSyncReturns } from "child_process";
+
+/**
+ * Wrapper for spawnSync to execute a command synchronously.
+ * @param command The command to run.
+ * @param args List of string arguments.
+ * @param options Options for process execution.
+ * @returns The result of spawnSync.
+ */
+export function runSync(
+  command: string,
+  args: string[] = [],
+  options: SpawnSyncOptions = {},
+): SpawnSyncReturns<Buffer> {
+  return spawnSync(command, args, { ...options, encoding: undefined });
+}


### PR DESCRIPTION
This pull request refactors the `serve` command in the CLI to improve process handling by replacing the use of `spawn` with a new utility function, `runSync`. The changes enhance error handling and ensure synchronous execution of the server bootstrap process.

### Refactoring process execution in `serve` command:

* [`src/cli/cmds/serve.ts`](diffhunk://#diff-0963fa9902a3ba1aa2e4128d8ea9bd361f17748d89afc806063cbf6a832e3799L14-R15): Replaced `spawn` with a newly introduced `runSync` utility to handle process execution synchronously. This change ensures better control over the process lifecycle and error handling. [[1]](diffhunk://#diff-0963fa9902a3ba1aa2e4128d8ea9bd361f17748d89afc806063cbf6a832e3799L14-R15) [[2]](diffhunk://#diff-0963fa9902a3ba1aa2e4128d8ea9bd361f17748d89afc806063cbf6a832e3799L79-R79)
* [`src/cli/cmds/serve.ts`](diffhunk://#diff-0963fa9902a3ba1aa2e4128d8ea9bd361f17748d89afc806063cbf6a832e3799R88-R97): Added a helper function, `exitCodeToError`, to interpret process exit codes and throw appropriate errors if the process fails.

### New utility function for synchronous process execution:

* [`src/cli/utils/run-sync.ts`](diffhunk://#diff-7ee1ebcefd06f1f48daa51e48ab7789e4cfffc1538946a7cfd15e1f14c63584fR1-R17): Introduced a `runSync` utility function as a wrapper around `spawnSync` to standardize synchronous process execution across the codebase. This includes support for customizable options and ensures consistent behavior.